### PR TITLE
fix: use get localhost instead of loopback address

### DIFF
--- a/AccessibilityInsightsForAndroidService/.idea/codeStyles/Project.xml
+++ b/AccessibilityInsightsForAndroidService/.idea/codeStyles/Project.xml
@@ -1,8 +1,5 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
-    <AndroidXmlCodeStyleSettings>
-      <option name="ARRANGEMENT_SETTINGS_MIGRATED_TO_191" value="true" />
-    </AndroidXmlCodeStyleSettings>
     <JetCodeStyleSettings>
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>

--- a/AccessibilityInsightsForAndroidService/.idea/gradle.xml
+++ b/AccessibilityInsightsForAndroidService/.idea/gradle.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <compositeConfiguration>
-          <compositeBuild compositeDefinitionSource="SCRIPT" />
-        </compositeConfiguration>
+        <option name="testRunner" value="PLATFORM" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="modules">
@@ -15,7 +14,6 @@
           </set>
         </option>
         <option name="resolveModulePerSourceSet" value="false" />
-        <option name="testRunner" value="PLATFORM" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/AccessibilityInsightsForAndroidService/app/build.gradle
+++ b/AccessibilityInsightsForAndroidService/app/build.gradle
@@ -4,12 +4,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
+    compileSdkVersion 28
     buildToolsVersion '28.0.3'
     defaultConfig {
         applicationId "com.microsoft.accessibilityinsightsforandroidservice"
-        minSdkVersion 26
-        targetSdkVersion 26
+        minSdkVersion 24
+        targetSdkVersion 28
         versionCode project.hasProperty("apkVersionCode") ? project.findProperty("apkVersionCode").toInteger() : 1
         versionName project.findProperty("apkVersionName") ?: "DEVELOPMENT"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ServerSocketFactory.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ServerSocketFactory.java
@@ -10,6 +10,6 @@ import java.net.ServerSocket;
 public class ServerSocketFactory {
   public ServerSocket createServerSocket(int serverPort) throws IOException {
     // Create a localhost-only server socket
-    return new ServerSocket(serverPort, 0, InetAddress.getLoopbackAddress());
+    return new ServerSocket(serverPort, 0, InetAddress.getLocalHost());
   }
 }


### PR DESCRIPTION
#### Description of changes

Validated with emulated device on OS 26 and OS 24.

#### Pull request checklist

<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] Addresses an existing issue: #0000
- [n/a] Added/updated relevant unit test(s)
- [ ] Ran `./gradlew fastpass` from `AccessibilityInsightsForAndroidService`
- [x] PR title _AND_ final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`).
