### PR TITLE
fix: Sign APK during release build using ESRP CodeSign

### DIFF
--- a/pipeline/release-build.yaml
+++ b/pipeline/release-build.yaml
@@ -32,6 +32,31 @@ jobs:
               testResultsFiles: '**/TEST-*.xml'
               tasks: 'build'
 
+          - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+            displayName: 'sign release apk with ESRP CodeSigning'
+            inputs:
+              ConnectedServiceName: 'Accessibility Insights for Android Service AAD APP Id'
+              FolderPath: '$(system.defaultWorkingDirectory)/AccessibilityInsightsForAndroidService/app/build/outputs/apk/release'
+              Pattern: '*.apk'
+              signConfigType: inlineSignParams
+              inlineOperation: |
+              [
+                      {
+                          "KeyCode" : "CP-458288-Java",
+                          "OperationCode" : "AndroidSign",
+                          "Parameters" : {},
+                          "ToolName" : "sign",
+                          "ToolVersion" : "1.0"
+                      },
+                      {
+                          "KeyCode" : "CP-458288-Java",
+                          "OperationCode" : "JavaVerify",
+                          "Parameters" : {},
+                          "ToolName" : "sign",
+                          "ToolVersion" : "1.0"
+                      }
+              ]
+
           - task: PublishPipelineArtifact@1
             displayName: publish apk folder as artifact
             inputs:

--- a/pipeline/release-build.yaml
+++ b/pipeline/release-build.yaml
@@ -40,22 +40,22 @@ jobs:
               Pattern: '*.apk'
               signConfigType: inlineSignParams
               inlineOperation: |
-              [
-                      {
-                          "KeyCode" : "CP-458288-Java",
-                          "OperationCode" : "AndroidSign",
-                          "Parameters" : {},
-                          "ToolName" : "sign",
-                          "ToolVersion" : "1.0"
-                      },
-                      {
-                          "KeyCode" : "CP-458288-Java",
-                          "OperationCode" : "JavaVerify",
-                          "Parameters" : {},
-                          "ToolName" : "sign",
-                          "ToolVersion" : "1.0"
-                      }
-              ]
+                [
+                        {
+                            "KeyCode" : "CP-458288-Java",
+                            "OperationCode" : "AndroidSign",
+                            "Parameters" : {},
+                            "ToolName" : "sign",
+                            "ToolVersion" : "1.0"
+                        },
+                        {
+                            "KeyCode" : "CP-458288-Java", 
+                            "OperationCode" : "JavaVerify",
+                            "Parameters" : {},
+                            "ToolName" : "sign",
+                            "ToolVersion" : "1.0"
+                        }
+                ]
 
           - task: PublishPipelineArtifact@1
             displayName: publish apk folder as artifact


### PR DESCRIPTION
#### Description of changes
Currently, no part of our build or release pipeline signs the APK. This PR introduces the ESRP CodeSign task to release-build.yaml to sign our APK. This will allow us to download the APK from the build artifact for testing purposes and to consume said APK in the release pipeline. You can find a [signed apk in the artifacts here](https://dev.azure.com/accessibility-insights-private/Accessibility%20Insights%20(private)/_build/results?buildId=10031&view=results). I verified that the cert of the newly published APK matches the cert of our previously published APK using `keytool -list -printcert -jarfile <apk>`.

#### Pull request checklist

<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] Addresses an existing issue: #0000
- [n/a] Added/updated relevant unit test(s)
- [n/a] Ran `./gradlew fastpass` from `AccessibilityInsightsForAndroidService`
- [x] PR title _AND_ final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`).
