### PR TITLE
fix(release-build): prevent future mismatches of versionName and versionCode

### DIFF
--- a/pipeline/infer-version-code-from-version-name.js
+++ b/pipeline/infer-version-code-from-version-name.js
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+const process = require('process');
+const versionName = process.env['APK_VERSION_NAME'];
+
+if (versionName == null) {
+    console.error('APK_VERSION_NAME env var not set!');
+    process.exit(1);
+}
+
+const versionNameRegex = /^(\d+)\.(\d+)\.(\d+)$/;
+const versionNameMatches = versionNameRegex.exec(versionName);
+if (versionNameMatches == null) {
+    console.error(`APK_VERSION_NAME ${versionName} not in expected format (1.2.3)`);
+    process.exit(1);
+}
+
+const [major, minor, patch] = versionNameMatches.slice(1).map(component => parseInt(component));
+if (`${major}.${minor}.${patch}` !== versionName) {
+    console.error(`APK_VERSION_NAME ${versionName} has extra leading zeros (should be ${major}.${minor}.${patch})`)
+    process.exit(1);
+}
+
+if (major > 99 || minor > 99 || patch > 999) {
+    console.error(`APK_VERSION_NAME ${versionName} has an oversized component; it must fit in format xx.yy.zzz`);
+    process.exit(1);
+}
+
+// for version x.y.z, versionCode is xxyyzzz
+const versionCode = (major * 100000) + (minor * 1000) + patch;
+console.log(`Success! Inferred version code: ${versionCode}`);
+
+// This is the magic syntax to set an output variable in Azure Pipelines
+console.log(`##vso[task.setvariable variable=APK_VERSION_CODE]${versionCode}`);

--- a/pipeline/release-build.yaml
+++ b/pipeline/release-build.yaml
@@ -13,18 +13,13 @@ jobs:
     steps:
       # setup dependencies
 
-      - script: | 
-          echo This build requires you to override APK_VERSION_NAME and APK_VERSION_CODE vars at queue-time
-          echo Refer to the release validation template for guidance on determining appropriate values
-          exit 1
-        displayName: ensure version vars are set
-        failOnStderr: true
-        condition: or(eq(variables['APK_VERSION_NAME'], 'REPLACE_ME'), eq(variables['APK_VERSION_CODE'], 'REPLACE_ME'))
-
       - task: NodeTool@0
         inputs:
           versionSpec: '12.x'
         displayName: use node 12.x (latest LTS)
+
+      - script: node $(system.defaultWorkingDirectory)/pipeline/infer-version-code-from-version-name.js
+        displayName: validate APK_VERSION_NAME and infer APK_VERSION_CODE
 
       # build
 


### PR DESCRIPTION
#### Description of changes

This PR is a preventative measure to avoid the class of issue described by #21; it removes the human step of specifying an APK_VERSION_CODE from our release process by having the build infer it automatically from APK_VERSION_NAME.

Once this PR is merged, I'll update the release validation template accordingly.

Out of scope for this PR: implementing the logic #21 suggests for validating that versionName is newer than all previous releases.

I verified manually that all of the error paths catch the issues that they're supposed to.

[Example build with successful APK_VERSION_CODE inference](https://dev.azure.com/accessibility-insights-private/Accessibility%20Insights%20(private)/_build/results?buildId=11257&view=results) (you can verify that the correct versionCode is applied by examining the [log output](https://dev.azure.com/accessibility-insights-private/Accessibility%20Insights%20(private)/_build/results?buildId=11257&view=logs&j=ee97c5d1-e7c0-57b6-e379-76cd471b81bc&t=3d498509-f466-517e-a654-0f6cf997d88d&l=14) of the "print out generated release APK info" build step).

#### Pull request checklist

<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [x] Addresses an existing issue: #21
- [n/a] Added/updated relevant unit test(s)
- [n/a] Ran `./gradlew fastpass` from `AccessibilityInsightsForAndroidService`
- [x] PR title _AND_ final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`).
