### PR TITLE
chore: update wrapper README per feedback from 1.2.0 validation

### DIFF
--- a/npm-wrapper/README.md
+++ b/npm-wrapper/README.md
@@ -1,6 +1,6 @@
 ## accessibility-insights-for-android-service-bin
 
-This NPM package is a thin wrapper around the [Accessibility Insights for Android Service](../README.md) APK file. The package bundles a copy of the APK and exports the path of the bundled APK (and its associated NOTICE file) as the only library exports.
+This NPM package is CommonJS module that acts as a thin wrapper around the [Accessibility Insights for Android Service](../README.md) APK file. The package bundles a copy of the APK and exports the path and version of the bundled APK (and its associated NOTICE file).
 
 This wrapper package is intended for consumption by [Accessibility Insights for Android](https://github.com/microsoft/accessibility-insights-web); **we make no guarantees about its API stability or fitness for other purposes.**
 
@@ -11,7 +11,8 @@ This wrapper package's version matches the version of the bundled APK. It **does
 ### Usage
 
 ```js
-import { noticePath, apkPath, apkVersionName } from 'accessibility-insights-for-android-service-bin';
+import serviceBin from 'accessibility-insights-for-android-service-bin';
+const { noticePath, apkPath, apkVersionName } = serviceBin;
 
 console.log(`Absolute path of the APK bundled with the package: ${apkPath}`);
 console.log(`APK_VERSION_NAME of the bundled APK: ${apkVersionName}`);

--- a/npm-wrapper/README.md
+++ b/npm-wrapper/README.md
@@ -4,15 +4,16 @@ This NPM package is CommonJS module that acts as a thin wrapper around the [Acce
 
 This wrapper package is intended for consumption by [Accessibility Insights for Android](https://github.com/microsoft/accessibility-insights-web); **we make no guarantees about its API stability or fitness for other purposes.**
 
+Note that the `apkPath` and `noticePath` exports are defined relative to `__dirname`, which means that they may not be usable in a bundled environment. For Accessibility Insights for Android, we read them during our build process and copy the files to a location our packaging setup understands. 
+
 ### Versioning
 
 This wrapper package's version matches the version of the bundled APK. It **does not use semantic versioning**; we reserve the right to make breaking API changes to the wrapper package without a major version update.
 
-### Usage
+### Typescript usage
 
-```js
-import serviceBin from 'accessibility-insights-for-android-service-bin';
-const { noticePath, apkPath, apkVersionName } = serviceBin;
+```ts
+import { noticePath, apkPath, apkVersionName } from 'accessibility-insights-for-android-service-bin';
 
 console.log(`Absolute path of the APK bundled with the package: ${apkPath}`);
 console.log(`APK_VERSION_NAME of the bundled APK: ${apkVersionName}`);


### PR DESCRIPTION
#### Description of changes

* Clarify that the wrapper is a CommonJS module
* Clarify that the usage example is for typescript (the import syntax is a little different in js)
* Clarify that it exports the version, not just the paths
* Clarify gotcha about `__dirname` usage that Dave noted

#### Pull request checklist

<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] Addresses an existing issue: #0000
- [n/a] Added/updated relevant unit test(s)
- [n/a] Ran `./gradlew fastpass` from `AccessibilityInsightsForAndroidService`
- [x] PR title _AND_ final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`).
