### PR TITLE
chore: fix release build to accomodate updated release output filename

### DIFF
--- a/pipeline/release-build.yaml
+++ b/pipeline/release-build.yaml
@@ -37,7 +37,7 @@ jobs:
           testResultsFiles: '**/TEST-*.xml'
           tasks: 'build'
 
-      - script: type $(system.defaultWorkingDirectory)\AccessibilityInsightsForAndroidService\app\build\outputs\apk\release\output.json
+      - script: type $(system.defaultWorkingDirectory)\AccessibilityInsightsForAndroidService\app\build\outputs\apk\release\output-metadata.json
         displayName: print out generated release APK info
 
       # unsigned-apk artifact


### PR DESCRIPTION
#### Description of changes

#34 updated our android build tools, and apparently the updated build tools now write release variable metadata into `output-metadata.json` where they previously used `output.json`. This broke a build task we have to print that file for debugging purposes.

#### Pull request checklist

<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] Addresses an existing issue: #0000
- [n/a] Added/updated relevant unit test(s)
- [x] Ran `./gradlew fastpass` from `AccessibilityInsightsForAndroidService`
- [x] PR title _AND_ final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`).
