### PR TITLE
chore(dev-deps): Clean up deps listings in build.gradle

### DIFF
--- a/AccessibilityInsightsForAndroidService/app/build.gradle
+++ b/AccessibilityInsightsForAndroidService/app/build.gradle
@@ -38,10 +38,13 @@ android {
 }
 
 dependencies {
-    androidTestImplementation('androidx.test.espresso:espresso-core:3.1.0')
+    // Non-dev dependencies (redistributed with releases)
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation 'com.deque.android:axe-android:0.2.0'
     implementation 'com.google.code.gson:gson:2.8.6'
+
+    // Dev dependencies (not redistributed)
+    androidTestImplementation('androidx.test.espresso:espresso-core:3.1.0')
     lintClassPath 'org.apache.commons:commons-compress:1.20'
     lintClassPath 'org.bouncycastle:bcpkix-jdk15on:1.66'
     lintClassPath 'org.bouncycastle:bcprov-jdk15on:1.66'

--- a/AccessibilityInsightsForAndroidService/app/build.gradle
+++ b/AccessibilityInsightsForAndroidService/app/build.gradle
@@ -38,22 +38,18 @@ android {
 }
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
-    androidTestImplementation('com.android.support.test.espresso:espresso-core:3.0.2', {
-        exclude group: 'com.android.support', module: 'support-annotations'
-    })
-//    implementation 'com.android.support:appcompat-v7:28.0.0'
-    implementation 'com.google.code.gson:gson:2.8.6'
+    androidTestImplementation('androidx.test.espresso:espresso-core:3.1.0')
     implementation 'androidx.annotation:annotation:1.1.0'
-    testImplementation 'junit:junit:4.13'
-    testImplementation 'org.mockito:mockito-core:3.5.9'
-    testImplementation 'org.powermock:powermock-core:2.0.7'
-    testImplementation 'org.powermock:powermock-module-junit4:2.0.7'
-    testImplementation 'org.powermock:powermock-api-mockito2:2.0.7'
+    implementation 'com.deque.android:axe-android:0.2.0'
+    implementation 'com.google.code.gson:gson:2.8.6'
+    lintClassPath 'org.apache.commons:commons-compress:1.20'
     lintClassPath 'org.bouncycastle:bcpkix-jdk15on:1.66'
     lintClassPath 'org.bouncycastle:bcprov-jdk15on:1.66'
-    lintClassPath 'org.apache.commons:commons-compress:1.20'
-    implementation 'com.deque.android:axe-android:0.2.0'
+    testImplementation 'junit:junit:4.13'
+    testImplementation 'org.mockito:mockito-core:3.5.9'
+    testImplementation 'org.powermock:powermock-api-mockito2:2.0.7'
+    testImplementation 'org.powermock:powermock-core:2.0.7'
+    testImplementation 'org.powermock:powermock-module-junit4:2.0.7'
 }
 
 configurations.all {

--- a/AccessibilityInsightsForAndroidService/app/gradle.lockfile
+++ b/AccessibilityInsightsForAndroidService/app/gradle.lockfile
@@ -2,10 +2,10 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 androidx.annotation:annotation:1.1.0=debugAndroidTestCompileClasspath,debugAndroidTestRuntimeClasspath,debugCompileClasspath,debugRuntimeClasspath,debugUnitTestCompileClasspath,debugUnitTestRuntimeClasspath,releaseCompileClasspath,releaseRuntimeClasspath,releaseUnitTestCompileClasspath,releaseUnitTestRuntimeClasspath
-androidx.test.espresso:espresso-core:3.1.0-alpha3=debugAndroidTestCompileClasspath,debugAndroidTestRuntimeClasspath
-androidx.test.espresso:espresso-idling-resource:3.1.0-alpha3=debugAndroidTestCompileClasspath,debugAndroidTestRuntimeClasspath
-androidx.test:monitor:1.1.0-alpha3=debugAndroidTestCompileClasspath,debugAndroidTestRuntimeClasspath
-androidx.test:runner:1.1.0-alpha3=debugAndroidTestCompileClasspath,debugAndroidTestRuntimeClasspath
+androidx.test.espresso:espresso-core:3.1.0=debugAndroidTestCompileClasspath,debugAndroidTestRuntimeClasspath
+androidx.test.espresso:espresso-idling-resource:3.1.0=debugAndroidTestCompileClasspath,debugAndroidTestRuntimeClasspath
+androidx.test:monitor:1.1.0=debugAndroidTestCompileClasspath,debugAndroidTestRuntimeClasspath
+androidx.test:runner:1.1.0=debugAndroidTestCompileClasspath,debugAndroidTestRuntimeClasspath
 com.android.tools.analytics-library:protos:27.0.1=lintClassPath
 com.android.tools.analytics-library:shared:27.0.1=lintClassPath
 com.android.tools.analytics-library:tracker:27.0.1=lintClassPath


### PR DESCRIPTION
#### Description of changes

This cleans up some outdated bits of build.gradle's `dependencies` block:

* Removes obsolete commented dependency
* Updates `androidTestImplementation` to use the more current `androidx` version rather than the deprecated `com.android.support` equivalent (this has the side effect of updating the lockfile to use stable rather than alpha versions of some testing libraries)
* Clarifies dev vs non-dev dependencies
* Sort lines

#### Pull request checklist

<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] Addresses an existing issue: #0000
- [n/a] Added/updated relevant unit test(s)
- [x] Ran `./gradlew fastpass` from `AccessibilityInsightsForAndroidService`
- [x] PR title _AND_ final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`).
