### PR TITLE
chore: Infer JAVA_HOME from default Android Studio install

### DIFF
--- a/AccessibilityInsightsForAndroidService/gradlew.bat
+++ b/AccessibilityInsightsForAndroidService/gradlew.bat
@@ -24,7 +24,20 @@ set JAVA_EXE=java.exe
 if "%ERRORLEVEL%" == "0" goto init
 
 echo.
-echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+echo WARNING: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+echo          Attempting to infer JAVA_HOME based on a default Android Studio
+echo          installation.
+echo.
+
+set JAVA_HOME=%ProgramFiles%\Android\Android Studio\jre
+set JAVA_EXE=%JAVA_HOME%\bin\java.exe
+"%JAVA_EXE%" -version >NUL 2>&1
+if "%ERRORLEVEL%" == "0" goto init
+set JAVA_HOME=
+
+echo.
+echo ERROR: JAVA_HOME is not set, could not be inferred from your Android Studio
+echo        installation, and no 'java' command could be found in your PATH.
 echo.
 echo Please set the JAVA_HOME variable in your environment to match the
 echo location of your Java installation.


### PR DESCRIPTION
#### Description of changes

When trying to run **gradlew fastpass**, I hit an error that JAVA_HOME wasn't set. That set me trying to figure out what was missing, and it turns out that java is installed as part of Android Studio, so nothing else needed to be done. This change adds an extra check to the initialization code and allows the default Android Studio location to be used. This seemed like a simpler approach than trying to tell people to download and install the JDK, since the JDK download process requires creating an account and may introduce licensing issues.

Output if JAVA_HOME _can't_ be inferred from default Android Studio install:
```
>gradlew fastpass

WARNING: JAVA_HOME is not set and no 'java' command could be found in your PATH.
         Attempting to infer JAVA_HOME based on a default Android Studio
         installation.


ERROR: JAVA_HOME is not set, could not be inferred from your Android Studio
       installation, and no 'java' command could be found in your PATH.

Please set the JAVA_HOME variable in your environment to match the
location of your Java installation.
```

Output if JAVA_HOME _can_ be inferred from default Android Studio install:
```
>gradlew fastpass

WARNING: JAVA_HOME is not set and no 'java' command could be found in your PATH.
         Attempting to infer JAVA_HOME based on a default Android Studio
         installation.


> Task :app:lint
  
Ran lint on variant debug: 3 issues found
Ran lint on variant release: 3 issues found
Wrote HTML report to file:
Wrote XML report to file:
Persisted dependency lock state for project ':app'

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.6/userguide/command_line_interface.html#sec:command_line_warnings

```

#### Pull request checklist
- [n/a] Addresses an existing issue: #0000
- [n/a] Added/updated relevant unit test(s)
- [x] Ran `./gradlew fastpass` from `AccessibilityInsightsForAndroidService`
- [x] PR title _AND_ final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`).
