### PR TITLE
fix: Add null class name workaround

### DIFF
--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/NodeViewBuilder.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/NodeViewBuilder.java
@@ -21,7 +21,9 @@ public class NodeViewBuilder implements AxeView.Builder {
 
   public String className() {
     String rawClassName = safeToString(accessibilityNode.getClassName());
-    return (rawClassName == null) ? "Class Name Not Specified--Inserted by Accessibility Insights" : rawClassName;
+    return (rawClassName == null)
+        ? "Class Name Not Specified--Inserted by Accessibility Insights"
+        : rawClassName;
   }
 
   public String contentDescription() {

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/NodeViewBuilder.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/NodeViewBuilder.java
@@ -20,7 +20,8 @@ public class NodeViewBuilder implements AxeView.Builder {
   }
 
   public String className() {
-    return safeToString(accessibilityNode.getClassName());
+    String rawClassName = safeToString(accessibilityNode.getClassName());
+    return (rawClassName == null) ? "Class Name Not Specified--Inserted by Accessibility Insights" : rawClassName;
   }
 
   public String contentDescription() {

--- a/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/NodeViewBuilderTest.java
+++ b/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/NodeViewBuilderTest.java
@@ -93,6 +93,17 @@ public class NodeViewBuilderTest {
     Assert.assertSame(viewLabeledBy, labeledBy);
   }
 
+  @Test
+  public void nodeViewHasNullClassName() {
+    AxeView labeledBy = mock(AxeView.class);
+    when(node.getClassName()).thenReturn(null);
+
+    testSubject = new NodeViewBuilder(node, children, labeledBy, rectProvider);
+    AxeView axeView = testSubject.build();
+
+    Assert.assertNotNull(axeView.className);
+  }
+
   private void setupBoundingRect() {
     doAnswer(
             AdditionalAnswers.answerVoid(


### PR DESCRIPTION
#### Description of changes

The axe-android code will throw an exception if className is null (see https://github.com/dequelabs/axe-android/issues/127 for details). For now, prevent that from happening by replacing the null value with a synthetic value that is clearly ours.

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

#### Pull request checklist

<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [x] Addresses an existing issue: #63 
- [x] Added/updated relevant unit test(s)
- [x] Ran `./gradlew fastpass` from `AccessibilityInsightsForAndroidService`
- [x] PR title _AND_ final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`).
