### PR TITLE
chore(deps): specify Google Maven as the exclusive provider of its deps

### DIFF
--- a/AccessibilityInsightsForAndroidService/build.gradle
+++ b/AccessibilityInsightsForAndroidService/build.gradle
@@ -6,7 +6,18 @@
 buildscript {
     repositories {
         jcenter()
-        google()
+        exclusiveContent {
+            forRepository {
+                google()
+            }
+            filter {
+                includeGroupByRegex("^androidx(\$|\\..*)")
+                includeGroupByRegex("^com\\.android(\$|\\..*)")
+                // Note: not all com.google.* cases come from google(), several are published
+                // to jcenter/mavenCentral only (eg, gson, protobuf, findbugs, guava, jimfs)
+                includeGroup("com.google.test.platform")
+            }
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.1'
@@ -23,7 +34,18 @@ plugins {
 allprojects {
     repositories {
         jcenter()
-        google()
+        exclusiveContent {
+            forRepository {
+                google()
+            }
+            filter {
+                includeGroupByRegex("^androidx(\$|\\..*)")
+                includeGroupByRegex("^com\\.android(\$|\\..*)")
+                // Note: not all com.google.* cases come from google(), several are published
+                // to jcenter/mavenCentral only (eg, gson, protobuf, findbugs, guava, jimfs)
+                includeGroup("com.google.test.platform")
+            }
+        }
     }
 }
 


### PR DESCRIPTION
#### Description of changes

This PR prevents a type of supply-chain substitution attack. Previously, for libraries which our build gets from Google's maven repository, our build first checks the maven repository provided by `jcenter()` for each library in question, and falls back to Google's in the event that it doesn't exist in `jcenter()`. If a malicious actor were to register one of those libraries' names on `jcenter()`, we would end up incorrectly using that version instead of the version from Google's Maven repository. With this PR, we direct Gradle to *only* look in the `google()` Maven repository for those libraries which we expect to come from there (and vice-versa).

The repetition between the `buildscript` and `allprojects` sections is undesirable, but I wasn't able to find a way to avoid it; Gradle considers it an error to put any statement besides a call to `buildscript` before the `plugins` directive, which precludes creating any sort of `commonRepositories = ...` directive before the `buildscript` directive, and I wasn't able to find a way to extract the `buildscript` repositories data back out to use as input to the later `allprojects` directive.

#### Pull request checklist

<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [x] Addresses an existing issue: 1802392
- [n/a] Added/updated relevant unit test(s)
- [x] Ran `./gradlew fastpass` from `AccessibilityInsightsForAndroidService`
- [x] PR title _AND_ final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`).
