### PR TITLE
feat(focus-mvp-android-client): create Accessiblity Event Dispatcher

### DIFF
--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/AccessibilityEventDispatcher.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/AccessibilityEventDispatcher.java
@@ -11,7 +11,7 @@ import java.util.List;
 import java.util.function.Consumer;
 
 public class AccessibilityEventDispatcher {
-  private static final String TAG = "AccessibilityEventDispa";
+  private static final String TAG = "AccessibilityEventDispatcher";
   private CharSequence previousPackageName;
 
   private ArrayList<Consumer<AccessibilityNodeInfo>> onAppChangedListeners;

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/AccessibilityEventDispatcher.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/AccessibilityEventDispatcher.java
@@ -1,72 +1,79 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 package com.microsoft.accessibilityinsightsforandroidservice;
 
-import android.util.Log;
 import android.view.accessibility.AccessibilityEvent;
 import android.view.accessibility.AccessibilityNodeInfo;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
 
 public class AccessibilityEventDispatcher {
-    private static final String TAG = "AccessibilityEventDispa";
-    private CharSequence previousPackageName;
+  private static final String TAG = "AccessibilityEventDispa";
+  private CharSequence previousPackageName;
 
-    private ArrayList<Consumer<AccessibilityNodeInfo>> onAppChangedListeners;
-    private ArrayList<Consumer<AccessibilityEvent>> onFocusEventListeners;
-    private ArrayList<Consumer<AccessibilityEvent>> onRedrawEventListeners;
+  private ArrayList<Consumer<AccessibilityNodeInfo>> onAppChangedListeners;
+  private ArrayList<Consumer<AccessibilityEvent>> onFocusEventListeners;
+  private ArrayList<Consumer<AccessibilityEvent>> onRedrawEventListeners;
 
-    public AccessibilityEventDispatcher() {
-        onAppChangedListeners = new ArrayList<Consumer<AccessibilityNodeInfo>>();
-        onFocusEventListeners = new ArrayList<Consumer<AccessibilityEvent>>();
-        onRedrawEventListeners = new ArrayList<Consumer<AccessibilityEvent>>();
+  public AccessibilityEventDispatcher() {
+    onAppChangedListeners = new ArrayList<Consumer<AccessibilityNodeInfo>>();
+    onFocusEventListeners = new ArrayList<Consumer<AccessibilityEvent>>();
+    onRedrawEventListeners = new ArrayList<Consumer<AccessibilityEvent>>();
+  }
+
+  public static List<Integer> redrawEventTypes =
+      Arrays.asList(
+          AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED,
+          AccessibilityEvent.TYPE_VIEW_SCROLLED,
+          AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED,
+          AccessibilityEvent.TYPE_WINDOWS_CHANGED);
+
+  public void onAccessibilityEvent(AccessibilityEvent event, AccessibilityNodeInfo rootNode) {
+    int eventType = event.getEventType();
+
+    if (previousPackageName == null || !previousPackageName.equals(rootNode.getPackageName())) {
+      previousPackageName = rootNode.getPackageName();
+      this.callListeners(onAppChangedListeners, rootNode);
     }
 
-    public static List<Integer> redrawEventTypes = Arrays.asList(AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED, AccessibilityEvent.TYPE_VIEW_SCROLLED, AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED, AccessibilityEvent.TYPE_WINDOWS_CHANGED);
-
-    public void onAccessibilityEvent(AccessibilityEvent event, AccessibilityNodeInfo rootNode) {
-        int eventType = event.getEventType();
-
-        if (previousPackageName == null || !previousPackageName.equals(rootNode.getPackageName())) {
-            previousPackageName = rootNode.getPackageName();
-            this.callListeners(onAppChangedListeners, rootNode);
-        }
-
-        if (isFocusEvent(eventType)) {
-            this.callListeners(onFocusEventListeners, event);
-            return;
-        }
-
-        if (isRedrawEvent(eventType)) {
-            this.callListeners(onRedrawEventListeners, event);
-            return;
-        }
+    if (isFocusEvent(eventType)) {
+      this.callListeners(onFocusEventListeners, event);
+      return;
     }
 
-    public void addOnFocusEventListener(Consumer<AccessibilityEvent> listener) {
-        onFocusEventListeners.add(listener);
+    if (isRedrawEvent(eventType)) {
+      this.callListeners(onRedrawEventListeners, event);
+      return;
     }
+  }
 
-    public void addOnRedrawEventListener(Consumer<AccessibilityEvent> listener) {
-        onRedrawEventListeners.add(listener);
-    }
+  public void addOnFocusEventListener(Consumer<AccessibilityEvent> listener) {
+    onFocusEventListeners.add(listener);
+  }
 
-    public void addOnAppChangedListener(Consumer<AccessibilityNodeInfo> listener) {
-        onAppChangedListeners.add(listener);
-    }
+  public void addOnRedrawEventListener(Consumer<AccessibilityEvent> listener) {
+    onRedrawEventListeners.add(listener);
+  }
 
-    private boolean isFocusEvent(int eventType) {
-        return eventType == AccessibilityEvent.TYPE_VIEW_FOCUSED;
-    }
+  public void addOnAppChangedListener(Consumer<AccessibilityNodeInfo> listener) {
+    onAppChangedListeners.add(listener);
+  }
 
-    private boolean isRedrawEvent(int eventType) {
-        return redrawEventTypes.contains(eventType);
-    }
+  private boolean isFocusEvent(int eventType) {
+    return eventType == AccessibilityEvent.TYPE_VIEW_FOCUSED;
+  }
 
-    private <T> void callListeners(ArrayList<Consumer<T>> listeners, T newValue) {
-        listeners.forEach(listener -> {
-            listener.accept(newValue);
+  private boolean isRedrawEvent(int eventType) {
+    return redrawEventTypes.contains(eventType);
+  }
+
+  private <T> void callListeners(ArrayList<Consumer<T>> listeners, T newValue) {
+    listeners.forEach(
+        listener -> {
+          listener.accept(newValue);
         });
-    }
+  }
 }

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/AccessibilityEventDispatcher.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/AccessibilityEventDispatcher.java
@@ -1,0 +1,72 @@
+package com.microsoft.accessibilityinsightsforandroidservice;
+
+import android.util.Log;
+import android.view.accessibility.AccessibilityEvent;
+import android.view.accessibility.AccessibilityNodeInfo;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Consumer;
+
+public class AccessibilityEventDispatcher {
+    private static final String TAG = "AccessibilityEventDispa";
+    private CharSequence previousPackageName;
+
+    private ArrayList<Consumer<AccessibilityNodeInfo>> onAppChangedListeners;
+    private ArrayList<Consumer<AccessibilityEvent>> onFocusEventListeners;
+    private ArrayList<Consumer<AccessibilityEvent>> onRedrawEventListeners;
+
+    public AccessibilityEventDispatcher() {
+        onAppChangedListeners = new ArrayList<Consumer<AccessibilityNodeInfo>>();
+        onFocusEventListeners = new ArrayList<Consumer<AccessibilityEvent>>();
+        onRedrawEventListeners = new ArrayList<Consumer<AccessibilityEvent>>();
+    }
+
+    public static List<Integer> redrawEventTypes = Arrays.asList(AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED, AccessibilityEvent.TYPE_VIEW_SCROLLED, AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED, AccessibilityEvent.TYPE_WINDOWS_CHANGED);
+
+    public void onAccessibilityEvent(AccessibilityEvent event, AccessibilityNodeInfo rootNode) {
+        int eventType = event.getEventType();
+
+        if (previousPackageName == null || !previousPackageName.equals(rootNode.getPackageName())) {
+            previousPackageName = rootNode.getPackageName();
+            this.callListeners(onAppChangedListeners, rootNode);
+        }
+
+        if (isFocusEvent(eventType)) {
+            this.callListeners(onFocusEventListeners, event);
+            return;
+        }
+
+        if (isRedrawEvent(eventType)) {
+            this.callListeners(onRedrawEventListeners, event);
+            return;
+        }
+    }
+
+    public void addOnFocusEventListener(Consumer<AccessibilityEvent> listener) {
+        onFocusEventListeners.add(listener);
+    }
+
+    public void addOnRedrawEventListener(Consumer<AccessibilityEvent> listener) {
+        onRedrawEventListeners.add(listener);
+    }
+
+    public void addOnAppChangedListener(Consumer<AccessibilityNodeInfo> listener) {
+        onAppChangedListeners.add(listener);
+    }
+
+    private boolean isFocusEvent(int eventType) {
+        return eventType == AccessibilityEvent.TYPE_VIEW_FOCUSED;
+    }
+
+    private boolean isRedrawEvent(int eventType) {
+        return redrawEventTypes.contains(eventType);
+    }
+
+    private <T> void callListeners(ArrayList<Consumer<T>> listeners, T newValue) {
+        listeners.forEach(listener -> {
+            listener.accept(newValue);
+        });
+    }
+}

--- a/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/AccessibilityEventDispatcherTest.java
+++ b/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/AccessibilityEventDispatcherTest.java
@@ -1,123 +1,119 @@
-package com.microsoft.accessibilityinsightsforandroidservice;
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
-import android.view.accessibility.AccessibilityEvent;
-import android.view.accessibility.AccessibilityNodeInfo;
+package com.microsoft.accessibilityinsightsforandroidservice;
 
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import android.view.accessibility.AccessibilityEvent;
+import android.view.accessibility.AccessibilityNodeInfo;
+import java.util.function.Consumer;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.reflect.Whitebox;
-
-import java.util.function.Consumer;
 
 @RunWith(PowerMockRunner.class)
 public class AccessibilityEventDispatcherTest {
 
-    @Mock
-    AccessibilityEvent eventMock;
-    @Mock
-    AccessibilityNodeInfo rootNodeMock;
-    @Mock
-    Consumer<AccessibilityNodeInfo> onAppChangedListenerMock;
-    @Mock
-    Consumer<AccessibilityEvent> onFocusEventListenerMock;
-    @Mock
-    Consumer<AccessibilityEvent> onRedrawEventListenerMock;
+  @Mock AccessibilityEvent eventMock;
+  @Mock AccessibilityNodeInfo rootNodeMock;
+  @Mock Consumer<AccessibilityNodeInfo> onAppChangedListenerMock;
+  @Mock Consumer<AccessibilityEvent> onFocusEventListenerMock;
+  @Mock Consumer<AccessibilityEvent> onRedrawEventListenerMock;
 
-    AccessibilityEventDispatcher testSubject;
+  AccessibilityEventDispatcher testSubject;
 
-    @Before
-    public void prepare() {
-        CharSequence packageNameStub = "some package name";
-        when(rootNodeMock.getPackageName()).thenReturn(packageNameStub);
+  @Before
+  public void prepare() {
+    CharSequence packageNameStub = "some package name";
+    when(rootNodeMock.getPackageName()).thenReturn(packageNameStub);
 
-        testSubject = new AccessibilityEventDispatcher();
-    }
+    testSubject = new AccessibilityEventDispatcher();
+  }
 
-    @Test
-    public void accessibilityEventDispatcherExists() {
-        Assert.assertNotNull(testSubject);
-    }
+  @Test
+  public void accessibilityEventDispatcherExists() {
+    Assert.assertNotNull(testSubject);
+  }
 
-    @Test
-    public void onAppChangedFiresWithoutPreviousPackageName() {
-        int trivialEventType = -1;
-        when(eventMock.getEventType()).thenReturn(trivialEventType);
+  @Test
+  public void onAppChangedFiresWithoutPreviousPackageName() {
+    int trivialEventType = -1;
+    when(eventMock.getEventType()).thenReturn(trivialEventType);
 
-        testSubject.addOnAppChangedListener(onAppChangedListenerMock);
-        testSubject.onAccessibilityEvent(eventMock, rootNodeMock);
+    testSubject.addOnAppChangedListener(onAppChangedListenerMock);
+    testSubject.onAccessibilityEvent(eventMock, rootNodeMock);
 
-        verify(onAppChangedListenerMock, times(1)).accept(rootNodeMock);
-    }
+    verify(onAppChangedListenerMock, times(1)).accept(rootNodeMock);
+  }
 
-    @Test
-    public void onAppChangedFiresWhenPackageNameChanged() {
-        int trivialEventType = -1;
-        CharSequence differentPackageNameStub = "different package name";
-        when(eventMock.getEventType()).thenReturn(trivialEventType);
+  @Test
+  public void onAppChangedFiresWhenPackageNameChanged() {
+    int trivialEventType = -1;
+    CharSequence differentPackageNameStub = "different package name";
+    when(eventMock.getEventType()).thenReturn(trivialEventType);
 
-        testSubject.addOnAppChangedListener(onAppChangedListenerMock);
-        testSubject.onAccessibilityEvent(eventMock, rootNodeMock);
+    testSubject.addOnAppChangedListener(onAppChangedListenerMock);
+    testSubject.onAccessibilityEvent(eventMock, rootNodeMock);
 
-        reset(rootNodeMock);
+    reset(rootNodeMock);
 
-        when(rootNodeMock.getPackageName()).thenReturn(differentPackageNameStub);
-        testSubject.onAccessibilityEvent(eventMock, rootNodeMock);
+    when(rootNodeMock.getPackageName()).thenReturn(differentPackageNameStub);
+    testSubject.onAccessibilityEvent(eventMock, rootNodeMock);
 
-        verify(onAppChangedListenerMock, times(2)).accept(rootNodeMock);
-    }
+    verify(onAppChangedListenerMock, times(2)).accept(rootNodeMock);
+  }
 
-    @Test
-    public void onFocusEventListenerFiresOnFocusEvent() {
-        int focusEventType = AccessibilityEvent.TYPE_VIEW_FOCUSED;
-        when(eventMock.getEventType()).thenReturn(focusEventType);
+  @Test
+  public void onFocusEventListenerFiresOnFocusEvent() {
+    int focusEventType = AccessibilityEvent.TYPE_VIEW_FOCUSED;
+    when(eventMock.getEventType()).thenReturn(focusEventType);
 
-        testSubject.addOnFocusEventListener(onFocusEventListenerMock);
-        testSubject.onAccessibilityEvent(eventMock, rootNodeMock);
+    testSubject.addOnFocusEventListener(onFocusEventListenerMock);
+    testSubject.onAccessibilityEvent(eventMock, rootNodeMock);
 
-        verify(onFocusEventListenerMock, times(1)).accept(eventMock);
-    }
+    verify(onFocusEventListenerMock, times(1)).accept(eventMock);
+  }
 
-    @Test
-    public void onFocusEventListenerDoesNotFiresOnOtherEvent() {
-        int trivialEventType = -1;
-        when(eventMock.getEventType()).thenReturn(trivialEventType);
+  @Test
+  public void onFocusEventListenerDoesNotFiresOnOtherEvent() {
+    int trivialEventType = -1;
+    when(eventMock.getEventType()).thenReturn(trivialEventType);
 
-        testSubject.addOnFocusEventListener(onFocusEventListenerMock);
-        testSubject.onAccessibilityEvent(eventMock, rootNodeMock);
+    testSubject.addOnFocusEventListener(onFocusEventListenerMock);
+    testSubject.onAccessibilityEvent(eventMock, rootNodeMock);
 
-        verify(onFocusEventListenerMock, times(0)).accept(eventMock);
-    }
+    verify(onFocusEventListenerMock, times(0)).accept(eventMock);
+  }
 
-    @Test
-    public void onRedrawEventListenerFiresOnRedrawEvents() {
-        testSubject.addOnRedrawEventListener(onRedrawEventListenerMock);
+  @Test
+  public void onRedrawEventListenerFiresOnRedrawEvents() {
+    testSubject.addOnRedrawEventListener(onRedrawEventListenerMock);
 
-        AccessibilityEventDispatcher.redrawEventTypes.forEach(eventType -> {
-            when(eventMock.getEventType()).thenReturn(eventType);
-            testSubject.onAccessibilityEvent(eventMock, rootNodeMock);
-            reset(eventMock);
+    AccessibilityEventDispatcher.redrawEventTypes.forEach(
+        eventType -> {
+          when(eventMock.getEventType()).thenReturn(eventType);
+          testSubject.onAccessibilityEvent(eventMock, rootNodeMock);
+          reset(eventMock);
         });
 
-        verify(onRedrawEventListenerMock, times(4)).accept(eventMock);
-    }
+    verify(onRedrawEventListenerMock, times(4)).accept(eventMock);
+  }
 
-    @Test
-    public void onRedrawEventListenerDoesNotFiresOnOtherEvent() {
-        int trivialEventType = -1;
-        when(eventMock.getEventType()).thenReturn(trivialEventType);
+  @Test
+  public void onRedrawEventListenerDoesNotFiresOnOtherEvent() {
+    int trivialEventType = -1;
+    when(eventMock.getEventType()).thenReturn(trivialEventType);
 
-        testSubject.addOnRedrawEventListener(onRedrawEventListenerMock);
-        testSubject.onAccessibilityEvent(eventMock, rootNodeMock);
+    testSubject.addOnRedrawEventListener(onRedrawEventListenerMock);
+    testSubject.onAccessibilityEvent(eventMock, rootNodeMock);
 
-        verify(onRedrawEventListenerMock, times(0)).accept(eventMock);
-    }
+    verify(onRedrawEventListenerMock, times(0)).accept(eventMock);
+  }
 }

--- a/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/AccessibilityEventDispatcherTest.java
+++ b/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/AccessibilityEventDispatcherTest.java
@@ -1,0 +1,123 @@
+package com.microsoft.accessibilityinsightsforandroidservice;
+
+import android.view.accessibility.AccessibilityEvent;
+import android.view.accessibility.AccessibilityNodeInfo;
+
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
+
+import java.util.function.Consumer;
+
+@RunWith(PowerMockRunner.class)
+public class AccessibilityEventDispatcherTest {
+
+    @Mock
+    AccessibilityEvent eventMock;
+    @Mock
+    AccessibilityNodeInfo rootNodeMock;
+    @Mock
+    Consumer<AccessibilityNodeInfo> onAppChangedListenerMock;
+    @Mock
+    Consumer<AccessibilityEvent> onFocusEventListenerMock;
+    @Mock
+    Consumer<AccessibilityEvent> onRedrawEventListenerMock;
+
+    AccessibilityEventDispatcher testSubject;
+
+    @Before
+    public void prepare() {
+        CharSequence packageNameStub = "some package name";
+        when(rootNodeMock.getPackageName()).thenReturn(packageNameStub);
+
+        testSubject = new AccessibilityEventDispatcher();
+    }
+
+    @Test
+    public void accessibilityEventDispatcherExists() {
+        Assert.assertNotNull(testSubject);
+    }
+
+    @Test
+    public void onAppChangedFiresWithoutPreviousPackageName() {
+        int trivialEventType = -1;
+        when(eventMock.getEventType()).thenReturn(trivialEventType);
+
+        testSubject.addOnAppChangedListener(onAppChangedListenerMock);
+        testSubject.onAccessibilityEvent(eventMock, rootNodeMock);
+
+        verify(onAppChangedListenerMock, times(1)).accept(rootNodeMock);
+    }
+
+    @Test
+    public void onAppChangedFiresWhenPackageNameChanged() {
+        int trivialEventType = -1;
+        CharSequence differentPackageNameStub = "different package name";
+        when(eventMock.getEventType()).thenReturn(trivialEventType);
+
+        testSubject.addOnAppChangedListener(onAppChangedListenerMock);
+        testSubject.onAccessibilityEvent(eventMock, rootNodeMock);
+
+        reset(rootNodeMock);
+
+        when(rootNodeMock.getPackageName()).thenReturn(differentPackageNameStub);
+        testSubject.onAccessibilityEvent(eventMock, rootNodeMock);
+
+        verify(onAppChangedListenerMock, times(2)).accept(rootNodeMock);
+    }
+
+    @Test
+    public void onFocusEventListenerFiresOnFocusEvent() {
+        int focusEventType = AccessibilityEvent.TYPE_VIEW_FOCUSED;
+        when(eventMock.getEventType()).thenReturn(focusEventType);
+
+        testSubject.addOnFocusEventListener(onFocusEventListenerMock);
+        testSubject.onAccessibilityEvent(eventMock, rootNodeMock);
+
+        verify(onFocusEventListenerMock, times(1)).accept(eventMock);
+    }
+
+    @Test
+    public void onFocusEventListenerDoesNotFiresOnOtherEvent() {
+        int trivialEventType = -1;
+        when(eventMock.getEventType()).thenReturn(trivialEventType);
+
+        testSubject.addOnFocusEventListener(onFocusEventListenerMock);
+        testSubject.onAccessibilityEvent(eventMock, rootNodeMock);
+
+        verify(onFocusEventListenerMock, times(0)).accept(eventMock);
+    }
+
+    @Test
+    public void onRedrawEventListenerFiresOnRedrawEvents() {
+        testSubject.addOnRedrawEventListener(onRedrawEventListenerMock);
+
+        AccessibilityEventDispatcher.redrawEventTypes.forEach(eventType -> {
+            when(eventMock.getEventType()).thenReturn(eventType);
+            testSubject.onAccessibilityEvent(eventMock, rootNodeMock);
+            reset(eventMock);
+        });
+
+        verify(onRedrawEventListenerMock, times(4)).accept(eventMock);
+    }
+
+    @Test
+    public void onRedrawEventListenerDoesNotFiresOnOtherEvent() {
+        int trivialEventType = -1;
+        when(eventMock.getEventType()).thenReturn(trivialEventType);
+
+        testSubject.addOnRedrawEventListener(onRedrawEventListenerMock);
+        testSubject.onAccessibilityEvent(eventMock, rootNodeMock);
+
+        verify(onRedrawEventListenerMock, times(0)).accept(eventMock);
+    }
+}


### PR DESCRIPTION
#### Details

Creates a class to be utilized later in the "onAccessibilityEvent" hook in the service.

##### Motivation

The tabstops feature requires us to listen to event types for accessibility events. This allows a specific place for that.

##### Context

I decided to go with an array of listeners because I figured it wasn't much more work to do so now and also this may allow us to break apart future components a bit more easily.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: #0000
- [x] Added/updated relevant unit test(s)
- [x] Ran `./gradlew fastpass` from `AccessibilityInsightsForAndroidService`
- [x] PR title _AND_ final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`).
