### PR TITLE
feat(focus-mvp-android-device): add focus visualization state manager

### DIFF
--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/Command.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/Command.java
@@ -1,8 +1,0 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
-
-package com.microsoft.accessibilityinsightsforandroidservice;
-
-public interface Command {
-  public void execute();
-}

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/Command.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/Command.java
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package com.microsoft.accessibilityinsightsforandroidservice;
+
+public interface Command {
+  public void execute();
+}

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/FocusVisualizationStateManager.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/FocusVisualizationStateManager.java
@@ -1,39 +1,36 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
-
 package com.microsoft.accessibilityinsightsforandroidservice;
 
 import java.util.ArrayList;
+import java.util.function.Consumer;
 
 public class FocusVisualizationStateManager {
-  private boolean enabled = false;
-  private ArrayList<Command> onChangedListeners;
+    private boolean enabled = false;
+    private ArrayList<Consumer<Boolean>> onChangedListeners;
 
-  public FocusVisualizationStateManager() {
-    onChangedListeners = new ArrayList<Command>();
-  }
-
-  public void subscribe(Command listener) {
-    onChangedListeners.add(listener);
-  }
-
-  public void setState(boolean enabled) {
-    if (this.enabled == enabled) {
-      return;
+    public FocusVisualizationStateManager() {
+        onChangedListeners = new ArrayList<Consumer<Boolean>>();
     }
 
-    this.enabled = enabled;
-    this.emitChanged();
-  }
+    public void subscribe(Consumer<Boolean> listener) {
+        onChangedListeners.add(listener);
+    }
 
-  public boolean getState() {
-    return this.enabled;
-  }
+    public void setState(boolean enabled) {
+        if (this.enabled == enabled) {
+            return;
+        }
 
-  private void emitChanged() {
-    onChangedListeners.forEach(
-        listener -> {
-          listener.execute();
+        this.enabled = enabled;
+        this.emitChanged(enabled);
+    }
+
+    public boolean getState() {
+        return this.enabled;
+    }
+
+    private void emitChanged(boolean enabled) {
+        onChangedListeners.forEach(listener -> {
+            listener.accept(enabled);
         });
-  }
+    }
 }

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/FocusVisualizationStateManager.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/FocusVisualizationStateManager.java
@@ -1,36 +1,40 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 package com.microsoft.accessibilityinsightsforandroidservice;
 
 import java.util.ArrayList;
 import java.util.function.Consumer;
 
 public class FocusVisualizationStateManager {
-    private boolean enabled = false;
-    private ArrayList<Consumer<Boolean>> onChangedListeners;
+  private boolean enabled = false;
+  private ArrayList<Consumer<Boolean>> onChangedListeners;
 
-    public FocusVisualizationStateManager() {
-        onChangedListeners = new ArrayList<Consumer<Boolean>>();
+  public FocusVisualizationStateManager() {
+    onChangedListeners = new ArrayList<Consumer<Boolean>>();
+  }
+
+  public void subscribe(Consumer<Boolean> listener) {
+    onChangedListeners.add(listener);
+  }
+
+  public void setState(boolean enabled) {
+    if (this.enabled == enabled) {
+      return;
     }
 
-    public void subscribe(Consumer<Boolean> listener) {
-        onChangedListeners.add(listener);
-    }
+    this.enabled = enabled;
+    this.emitChanged(enabled);
+  }
 
-    public void setState(boolean enabled) {
-        if (this.enabled == enabled) {
-            return;
-        }
+  public boolean getState() {
+    return this.enabled;
+  }
 
-        this.enabled = enabled;
-        this.emitChanged(enabled);
-    }
-
-    public boolean getState() {
-        return this.enabled;
-    }
-
-    private void emitChanged(boolean enabled) {
-        onChangedListeners.forEach(listener -> {
-            listener.accept(enabled);
+  private void emitChanged(boolean enabled) {
+    onChangedListeners.forEach(
+        listener -> {
+          listener.accept(enabled);
         });
-    }
+  }
 }

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/FocusVisualizationStateManager.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/FocusVisualizationStateManager.java
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package com.microsoft.accessibilityinsightsforandroidservice;
+
+import java.util.ArrayList;
+
+public class FocusVisualizationStateManager {
+  private boolean enabled = false;
+  private ArrayList<Command> onChangedListeners;
+
+  public FocusVisualizationStateManager() {
+    onChangedListeners = new ArrayList<Command>();
+  }
+
+  public void subscribe(Command listener) {
+    onChangedListeners.add(listener);
+  }
+
+  public void setState(boolean enabled) {
+    if (this.enabled == enabled) {
+      return;
+    }
+
+    this.enabled = enabled;
+    this.emitChanged();
+  }
+
+  public boolean getState() {
+    return this.enabled;
+  }
+
+  private void emitChanged() {
+    onChangedListeners.forEach(
+        listener -> {
+          listener.execute();
+        });
+  }
+}

--- a/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/FocusVisualizationStateManagerTest.java
+++ b/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/FocusVisualizationStateManagerTest.java
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package com.microsoft.accessibilityinsightsforandroidservice;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+@RunWith(PowerMockRunner.class)
+public class FocusVisualizationStateManagerTest {
+
+  @Mock Command onChangeMock;
+
+  FocusVisualizationStateManager testSubject;
+
+  @Before
+  public void prepare() {
+    testSubject = new FocusVisualizationStateManager();
+  }
+
+  @Test
+  public void exists() {
+    Assert.assertNotNull(testSubject);
+  }
+
+  @Test
+  public void getStateReturnsFalseByDefault() {
+    Assert.assertFalse(testSubject.getState());
+  }
+
+  @Test
+  public void getStateReturnsUpdatedState() {
+    testSubject.setState(true);
+    Assert.assertTrue(testSubject.getState());
+  }
+
+  @Test
+  public void setStateDoesNotCallOnChangeListenersIfStateDoesNotChange() {
+    testSubject.subscribe(onChangeMock);
+    testSubject.setState(false);
+    verify(onChangeMock, times(0)).execute();
+  }
+
+  @Test
+  public void setStateCallsOnChangeListenersOnStateChange() {
+    testSubject.subscribe(onChangeMock);
+    testSubject.setState(true);
+    Assert.assertTrue(testSubject.getState());
+    verify(onChangeMock, times(1)).execute();
+  }
+}

--- a/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/FocusVisualizationStateManagerTest.java
+++ b/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/FocusVisualizationStateManagerTest.java
@@ -1,7 +1,12 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 package com.microsoft.accessibilityinsightsforandroidservice;
 
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+
+import java.util.function.Consumer;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -9,49 +14,46 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import java.util.function.Consumer;
-
 @RunWith(PowerMockRunner.class)
 public class FocusVisualizationStateManagerTest {
 
-    @Mock
-    Consumer<Boolean> onChangeMock;
+  @Mock Consumer<Boolean> onChangeMock;
 
-    FocusVisualizationStateManager testSubject;
+  FocusVisualizationStateManager testSubject;
 
-    @Before
-    public void prepare() {
-        testSubject = new FocusVisualizationStateManager();
-    }
+  @Before
+  public void prepare() {
+    testSubject = new FocusVisualizationStateManager();
+  }
 
-    @Test
-    public void exists() {
-        Assert.assertNotNull(testSubject);
-    }
+  @Test
+  public void exists() {
+    Assert.assertNotNull(testSubject);
+  }
 
-    @Test
-    public void getStateReturnsFalseByDefault() {
-        Assert.assertFalse(testSubject.getState());
-    }
+  @Test
+  public void getStateReturnsFalseByDefault() {
+    Assert.assertFalse(testSubject.getState());
+  }
 
-    @Test
-    public void getStateReturnsUpdatedState() {
-        testSubject.setState(true);
-        Assert.assertTrue(testSubject.getState());
-    }
+  @Test
+  public void getStateReturnsUpdatedState() {
+    testSubject.setState(true);
+    Assert.assertTrue(testSubject.getState());
+  }
 
-    @Test
-    public void setStateDoesNotCallOnChangeListenersIfStateDoesNotChange() {
-        testSubject.subscribe(onChangeMock);
-        testSubject.setState(false);
-        verify(onChangeMock, times(0)).accept(false);
-    }
+  @Test
+  public void setStateDoesNotCallOnChangeListenersIfStateDoesNotChange() {
+    testSubject.subscribe(onChangeMock);
+    testSubject.setState(false);
+    verify(onChangeMock, times(0)).accept(false);
+  }
 
-    @Test
-    public void setStateCallsOnChangeListenersOnStateChange() {
-        testSubject.subscribe(onChangeMock);
-        testSubject.setState(true);
-        Assert.assertTrue(testSubject.getState());
-        verify(onChangeMock, times(1)).accept(true);
-    }
+  @Test
+  public void setStateCallsOnChangeListenersOnStateChange() {
+    testSubject.subscribe(onChangeMock);
+    testSubject.setState(true);
+    Assert.assertTrue(testSubject.getState());
+    verify(onChangeMock, times(1)).accept(true);
+  }
 }

--- a/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/FocusVisualizationStateManagerTest.java
+++ b/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/FocusVisualizationStateManagerTest.java
@@ -1,11 +1,7 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
-
 package com.microsoft.accessibilityinsightsforandroidservice;
 
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -13,46 +9,49 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.util.function.Consumer;
+
 @RunWith(PowerMockRunner.class)
 public class FocusVisualizationStateManagerTest {
 
-  @Mock Command onChangeMock;
+    @Mock
+    Consumer<Boolean> onChangeMock;
 
-  FocusVisualizationStateManager testSubject;
+    FocusVisualizationStateManager testSubject;
 
-  @Before
-  public void prepare() {
-    testSubject = new FocusVisualizationStateManager();
-  }
+    @Before
+    public void prepare() {
+        testSubject = new FocusVisualizationStateManager();
+    }
 
-  @Test
-  public void exists() {
-    Assert.assertNotNull(testSubject);
-  }
+    @Test
+    public void exists() {
+        Assert.assertNotNull(testSubject);
+    }
 
-  @Test
-  public void getStateReturnsFalseByDefault() {
-    Assert.assertFalse(testSubject.getState());
-  }
+    @Test
+    public void getStateReturnsFalseByDefault() {
+        Assert.assertFalse(testSubject.getState());
+    }
 
-  @Test
-  public void getStateReturnsUpdatedState() {
-    testSubject.setState(true);
-    Assert.assertTrue(testSubject.getState());
-  }
+    @Test
+    public void getStateReturnsUpdatedState() {
+        testSubject.setState(true);
+        Assert.assertTrue(testSubject.getState());
+    }
 
-  @Test
-  public void setStateDoesNotCallOnChangeListenersIfStateDoesNotChange() {
-    testSubject.subscribe(onChangeMock);
-    testSubject.setState(false);
-    verify(onChangeMock, times(0)).execute();
-  }
+    @Test
+    public void setStateDoesNotCallOnChangeListenersIfStateDoesNotChange() {
+        testSubject.subscribe(onChangeMock);
+        testSubject.setState(false);
+        verify(onChangeMock, times(0)).accept(false);
+    }
 
-  @Test
-  public void setStateCallsOnChangeListenersOnStateChange() {
-    testSubject.subscribe(onChangeMock);
-    testSubject.setState(true);
-    Assert.assertTrue(testSubject.getState());
-    verify(onChangeMock, times(1)).execute();
-  }
+    @Test
+    public void setStateCallsOnChangeListenersOnStateChange() {
+        testSubject.subscribe(onChangeMock);
+        testSubject.setState(true);
+        Assert.assertTrue(testSubject.getState());
+        verify(onChangeMock, times(1)).accept(true);
+    }
 }


### PR DESCRIPTION
#### Details

Adds a place to manage the state for the focus visualization.

##### Motivation

For tab stops feature.

##### Context

Does not include usage.

Command is a functional interface like Consumer but takes no arguments.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: #0000
- [x] Added/updated relevant unit test(s)
- [x] Ran `./gradlew fastpass` from `AccessibilityInsightsForAndroidService`
- [x] PR title _AND_ final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`).
