### PR TITLE
feat(focus-mvp-android-device): add focus visualizer controller + related classes

### DIFF
--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/FocusVisualizerController.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/FocusVisualizerController.java
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package com.microsoft.accessibilityinsightsforandroidservice;
+
+import android.view.accessibility.AccessibilityEvent;
+
+public class FocusVisualizerController {
+  private FocusVisualizer focusVisualizer;
+  private FocusVisualizationStateManager focusVisualizationStateManager;
+  private UIThreadRunner uiThreadRunner;
+
+  public FocusVisualizerController(
+      FocusVisualizer focusVisualizer,
+      FocusVisualizationStateManager focusVisualizationStateManager,
+      UIThreadRunner uiThreadRunner) {
+    this.focusVisualizer = focusVisualizer;
+    this.focusVisualizationStateManager = focusVisualizationStateManager;
+    this.uiThreadRunner = uiThreadRunner;
+    this.focusVisualizationStateManager.subscribe(this::onFocusVisualizationStateChange);
+  }
+
+  public void onFocusEvent(AccessibilityEvent event) {
+    if (focusVisualizationStateManager.getState() == false) {
+      return;
+    }
+
+    focusVisualizer.HandleAccessibilityFocusEvent(event);
+  }
+
+  public void onRedrawEvent(AccessibilityEvent event) {
+    if (focusVisualizationStateManager.getState() == false) {
+      return;
+    }
+
+    focusVisualizer.HandleAccessibilityRedrawEvent(event);
+  }
+
+  private void onFocusVisualizationStateChange(boolean newState) {
+    if (newState) {
+      return;
+    }
+
+    uiThreadRunner.run(focusVisualizer::resetVisualizations);
+  }
+}

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/LayoutParamGenerator.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/LayoutParamGenerator.java
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package com.microsoft.accessibilityinsightsforandroidservice;
+
+import android.graphics.PixelFormat;
+import android.util.DisplayMetrics;
+import android.view.WindowManager;
+import java.util.function.Supplier;
+
+public class LayoutParamGenerator {
+  private Supplier<DisplayMetrics> displayMetricsSupplier;
+
+  public LayoutParamGenerator(Supplier<DisplayMetrics> displayMetricsSupplier) {
+    this.displayMetricsSupplier = displayMetricsSupplier;
+  }
+
+  public WindowManager.LayoutParams get() {
+    DisplayMetrics displayMetrics = displayMetricsSupplier.get();
+    WindowManager.LayoutParams params =
+        new WindowManager.LayoutParams(
+            displayMetrics.widthPixels,
+            displayMetrics.heightPixels,
+            WindowManager.LayoutParams.TYPE_ACCESSIBILITY_OVERLAY,
+            WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE
+                | WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE
+                | WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN
+                | WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
+            PixelFormat.TRANSLUCENT);
+
+    return params;
+  }
+}

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/UIThreadRunner.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/UIThreadRunner.java
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package com.microsoft.accessibilityinsightsforandroidservice;
+
+import android.os.Handler;
+import android.os.Looper;
+
+public class UIThreadRunner {
+  public void run(Runnable runnable) {
+    new Handler(Looper.getMainLooper()).post(runnable);
+  }
+}

--- a/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/FocusVisualizerControllerTest.java
+++ b/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/FocusVisualizerControllerTest.java
@@ -1,0 +1,132 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package com.microsoft.accessibilityinsightsforandroidservice;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.doAnswer;
+
+import android.view.accessibility.AccessibilityEvent;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Consumer;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+@RunWith(PowerMockRunner.class)
+public class FocusVisualizerControllerTest {
+
+  private static final ScheduledExecutorService mainThread =
+      Executors.newSingleThreadScheduledExecutor();
+  @Mock FocusVisualizer focusVisualizerMock;
+  @Mock FocusVisualizationStateManager focusVisualizationStateManagerMock;
+  @Mock AccessibilityEvent accessibilityEventMock;
+  @Mock UIThreadRunner uiThreadRunner;
+  @Mock Consumer<Boolean> listenerStub;
+
+  FocusVisualizerController testSubject;
+
+  @Test
+  public void exists() {
+    testSubject =
+        new FocusVisualizerController(
+            focusVisualizerMock, focusVisualizationStateManagerMock, uiThreadRunner);
+    Assert.assertNotNull(testSubject);
+  }
+
+  @Test
+  public void onFocusEventDoesNotCallVisualizerIfStateIsFalse() {
+    testSubject =
+        new FocusVisualizerController(
+            focusVisualizerMock, focusVisualizationStateManagerMock, uiThreadRunner);
+    when(focusVisualizationStateManagerMock.getState()).thenReturn(false);
+    testSubject.onFocusEvent(accessibilityEventMock);
+    verify(focusVisualizerMock, times(0))
+        .HandleAccessibilityFocusEvent(any(AccessibilityEvent.class));
+  }
+
+  @Test
+  public void onFocusEventCallsVisualizerIfStateIsTrue() {
+    testSubject =
+        new FocusVisualizerController(
+            focusVisualizerMock, focusVisualizationStateManagerMock, uiThreadRunner);
+    when(focusVisualizationStateManagerMock.getState()).thenReturn(true);
+    testSubject.onFocusEvent(accessibilityEventMock);
+    verify(focusVisualizerMock, times(1))
+        .HandleAccessibilityFocusEvent(any(AccessibilityEvent.class));
+  }
+
+  @Test
+  public void onRedrawEventDoesNotCallVisualizerIfStateIsFalse() {
+    testSubject =
+        new FocusVisualizerController(
+            focusVisualizerMock, focusVisualizationStateManagerMock, uiThreadRunner);
+    when(focusVisualizationStateManagerMock.getState()).thenReturn(false);
+    testSubject.onRedrawEvent(accessibilityEventMock);
+    verify(focusVisualizerMock, times(0))
+        .HandleAccessibilityRedrawEvent(any(AccessibilityEvent.class));
+  }
+
+  @Test
+  public void onRedrawEventCallsVisualizerIfStateIsTrue() {
+    testSubject =
+        new FocusVisualizerController(
+            focusVisualizerMock, focusVisualizationStateManagerMock, uiThreadRunner);
+    when(focusVisualizationStateManagerMock.getState()).thenReturn(true);
+    testSubject.onRedrawEvent(accessibilityEventMock);
+    verify(focusVisualizerMock, times(1))
+        .HandleAccessibilityRedrawEvent(any(AccessibilityEvent.class));
+  }
+
+  @Test
+  public void onFocusVisualizationStateChangeWithoutStateChangeDoesNothing() {
+    doAnswer(
+            invocation -> {
+              Consumer<Boolean> listener = invocation.getArgument(0);
+              listener.accept(true);
+              return null;
+            })
+        .when(focusVisualizationStateManagerMock)
+        .subscribe(any());
+
+    testSubject =
+        new FocusVisualizerController(
+            focusVisualizerMock, focusVisualizationStateManagerMock, uiThreadRunner);
+
+    verifyNoInteractions(uiThreadRunner);
+  }
+
+  @Test
+  public void onFocusVisualizationStateChangeResetsVisualizationsOnUIThread() {
+    doAnswer(
+            invocation -> {
+              Consumer<Boolean> listener = invocation.getArgument(0);
+              listener.accept(false);
+              return null;
+            })
+        .when(focusVisualizationStateManagerMock)
+        .subscribe(any());
+
+    doAnswer(
+            invocation -> {
+              Runnable runnable = invocation.getArgument(0);
+              runnable.run();
+              return null;
+            })
+        .when(uiThreadRunner)
+        .run(any());
+
+    testSubject =
+        new FocusVisualizerController(
+            focusVisualizerMock, focusVisualizationStateManagerMock, uiThreadRunner);
+
+    verify(focusVisualizerMock).resetVisualizations();
+  }
+}

--- a/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/LayoutParamGeneratorTest.java
+++ b/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/LayoutParamGeneratorTest.java
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package com.microsoft.accessibilityinsightsforandroidservice;
+
+import static org.powermock.api.mockito.PowerMockito.when;
+import static org.powermock.api.mockito.PowerMockito.whenNew;
+
+import android.graphics.PixelFormat;
+import android.util.DisplayMetrics;
+import android.view.WindowManager;
+import java.util.function.Supplier;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+@RunWith(PowerMockRunner.class)
+public class LayoutParamGeneratorTest {
+
+  @Mock Supplier<DisplayMetrics> displayMetricsSupplier;
+
+  @Mock WindowManager.LayoutParams layoutParams;
+
+  @Mock DisplayMetrics displayMetrics;
+
+  LayoutParamGenerator testSubject;
+
+  @Before
+  public void prepare() {
+    testSubject = new LayoutParamGenerator(displayMetricsSupplier);
+  }
+
+  @Test
+  public void generatesLayoutParams() throws Exception {
+    when(displayMetricsSupplier.get()).thenReturn(displayMetrics);
+    whenNew(WindowManager.LayoutParams.class)
+        .withArguments(
+            displayMetrics.widthPixels,
+            displayMetrics.heightPixels,
+            WindowManager.LayoutParams.TYPE_ACCESSIBILITY_OVERLAY,
+            WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE
+                | WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE
+                | WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN
+                | WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
+            PixelFormat.TRANSLUCENT)
+        .thenReturn(layoutParams);
+
+    // Cannot check for equality due to not being able to mock toString on LayoutParams
+    Assert.assertNotNull(testSubject.get());
+  }
+}

--- a/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/UIThreadRunnerTest.java
+++ b/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/UIThreadRunnerTest.java
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package com.microsoft.accessibilityinsightsforandroidservice;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.whenNew;
+
+import android.os.Handler;
+import android.os.Looper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({Looper.class, UIThreadRunner.class})
+public class UIThreadRunnerTest {
+
+  @Mock Looper looperMock;
+  @Mock Handler handlerMock;
+  @Mock Runnable runnableMock;
+
+  UIThreadRunner testSubject;
+
+  @Test
+  public void createsNewHandlerUsingMainLooper() throws Exception {
+    PowerMockito.mockStatic(Looper.class);
+    when(Looper.getMainLooper()).thenReturn(looperMock);
+    whenNew(Handler.class).withArguments(looperMock).thenReturn(handlerMock);
+
+    doAnswer(
+            invocation -> {
+              Runnable runnable = invocation.getArgument(0);
+              runnable.run();
+              return null;
+            })
+        .when(handlerMock)
+        .post(any());
+
+    testSubject = new UIThreadRunner();
+    testSubject.run(runnableMock);
+
+    verify(runnableMock).run();
+  }
+}


### PR DESCRIPTION
#### Details

Adds focus visualizer controller which should manage when to pass on focus/redraw events and other such aspects of the focus visualization.

##### Motivation

Feature work

##### Context

Does not include wiring up.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: #0000
- [x] Added/updated relevant unit test(s)
- [x] Ran `./gradlew fastpass` from `AccessibilityInsightsForAndroidService`
- [x] PR title _AND_ final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`).
