### PR TITLE
feat(focus-mvp-android-device): fix redraw event types

### DIFF
--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/AccessibilityEventDispatcher.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/AccessibilityEventDispatcher.java
@@ -26,8 +26,8 @@ public class AccessibilityEventDispatcher {
 
   public static List<Integer> redrawEventTypes =
       Arrays.asList(
+          AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED,
           AccessibilityEvent.TYPE_VIEW_SCROLLED,
-          AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED,
           AccessibilityEvent.TYPE_WINDOWS_CHANGED);
 
   public void onAccessibilityEvent(AccessibilityEvent event, AccessibilityNodeInfo rootNode) {


### PR DESCRIPTION
#### Details

We meant to remove TYPE_WINDOW_CONTENT_CHANGED but accidentally removed TYPE_WINDOW_STATE_CHANGED from the redraw events in a previous PR.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] Addresses an existing issue: #0000
- [n/a] Added/updated relevant unit test(s)
- [x] Ran `./gradlew fastpass` from `AccessibilityInsightsForAndroidService`
- [x] PR title _AND_ final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`).
