### PR TITLE
feat(focus-mvp-android-device): updates visualizations when elements are not present

### DIFF
--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/AccessibilityEventDispatcher.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/AccessibilityEventDispatcher.java
@@ -27,6 +27,7 @@ public class AccessibilityEventDispatcher {
   public static List<Integer> redrawEventTypes =
       Arrays.asList(
           AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED,
+          AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED,
           AccessibilityEvent.TYPE_VIEW_SCROLLED,
           AccessibilityEvent.TYPE_WINDOWS_CHANGED);
 

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/FocusElementHighlight.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/FocusElementHighlight.java
@@ -20,6 +20,7 @@ public class FocusElementHighlight {
   private HashMap<String, Paint> paints;
   private Rect rect;
   private View view;
+  private static final String TAG = "FocusElementHighlight";
 
   public FocusElementHighlight(
       AccessibilityNodeInfo eventSource,
@@ -33,16 +34,9 @@ public class FocusElementHighlight {
     this.radius = radius;
     this.rect = new Rect();
     this.paints = currentPaints;
-    this.updateWithNewCoordinates();
   }
 
   private void setCoordinates() {
-    if (this.eventSource == null) {
-      return;
-    }
-    if (!this.eventSource.refresh()) {
-      return;
-    }
     this.eventSource.getBoundsInScreen(this.rect);
     this.rect.offset(0, this.yOffset);
     this.xCoordinate = rect.centerX();
@@ -50,6 +44,16 @@ public class FocusElementHighlight {
   }
 
   public void drawElementHighlight(Canvas canvas) {
+    if (this.eventSource == null) {
+      return;
+    }
+
+    if (!this.eventSource.refresh()) {
+      return;
+    }
+
+    this.updateWithNewCoordinates();
+
     this.drawInnerCircle(
         this.xCoordinate, this.yCoordinate, this.radius, this.paints.get("innerCircle"), canvas);
     this.drawNumberInCircle(
@@ -85,7 +89,7 @@ public class FocusElementHighlight {
     return this.eventSource;
   }
 
-  public void updateWithNewCoordinates() {
+  private void updateWithNewCoordinates() {
     this.yOffset = OffsetHelper.getYOffset(this.view);
     this.setCoordinates();
   }

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/FocusElementLine.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/FocusElementLine.java
@@ -34,10 +34,18 @@ public class FocusElementLine {
     this.paints = Paints;
     this.currentRect = new Rect();
     this.prevRect = new Rect();
-    this.updateWithNewCoordinates();
   }
 
   public void drawLine(Canvas canvas) {
+    if (this.eventSource == null || this.previousEventSource == null) {
+      return;
+    }
+
+    if (!this.eventSource.refresh() || !this.previousEventSource.refresh()) {
+      return;
+    }
+
+    this.updateWithNewCoordinates();
     this.drawConnectingLine(
         this.xStart, this.yStart, this.xEnd, this.yEnd, this.paints.get("backgroundLine"), canvas);
     this.drawConnectingLine(
@@ -45,13 +53,6 @@ public class FocusElementLine {
   }
 
   private void setCoordinates() {
-    if (this.eventSource == null || this.previousEventSource == null) {
-      return;
-    }
-    if (!this.eventSource.refresh() || !this.previousEventSource.refresh()) {
-      return;
-    }
-
     this.eventSource.getBoundsInScreen(this.currentRect);
     this.currentRect.offset(0, this.yOffset);
 
@@ -73,7 +74,7 @@ public class FocusElementLine {
     this.paints = paints;
   }
 
-  public void updateWithNewCoordinates() {
+  private void updateWithNewCoordinates() {
     this.yOffset = OffsetHelper.getYOffset(this.view);
     this.setCoordinates();
   }

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/FocusVisualizer.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/FocusVisualizer.java
@@ -25,7 +25,7 @@ public class FocusVisualizer {
   }
 
   public void refreshHighlights() {
-    this.updateDrawingsWithNewCoordinates();
+    this.focusVisualizationCanvas.redraw();
   }
 
   public void addNewFocusedElement(AccessibilityEvent event) {
@@ -94,16 +94,6 @@ public class FocusVisualizer {
 
   private void setDrawItemsAndRedraw() {
     this.focusVisualizationCanvas.setDrawItems(this.focusElementHighlights, this.focusElementLines);
-    this.focusVisualizationCanvas.redraw();
-  }
-
-  private void updateDrawingsWithNewCoordinates() {
-    for (int i = 0; i < this.focusElementHighlights.size(); i++) {
-      this.focusElementHighlights.get(i).updateWithNewCoordinates();
-    }
-    for (int i = 0; i < this.focusElementLines.size(); i++) {
-      this.focusElementLines.get(i).updateWithNewCoordinates();
-    }
     this.focusVisualizationCanvas.redraw();
   }
 }

--- a/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/AccessibilityEventDispatcherTest.java
+++ b/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/AccessibilityEventDispatcherTest.java
@@ -114,7 +114,7 @@ public class AccessibilityEventDispatcherTest {
           reset(eventMock);
         });
 
-    verify(onRedrawEventListenerMock, times(3)).accept(eventMock);
+    verify(onRedrawEventListenerMock, times(4)).accept(eventMock);
   }
 
   @Test

--- a/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/FocusElementHighlightTest.java
+++ b/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/FocusElementHighlightTest.java
@@ -6,12 +6,11 @@ package com.microsoft.accessibilityinsightsforandroidservice;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
 import static org.powermock.api.mockito.PowerMockito.doNothing;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.spy;
 import static org.powermock.api.mockito.PowerMockito.verifyPrivate;
-import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
 import static org.powermock.api.mockito.PowerMockito.whenNew;
 
@@ -42,10 +41,11 @@ public class FocusElementHighlightTest {
   @Mock Resources resourcesMock;
   @Mock Rect rectMock;
   @Mock Canvas canvasMock;
+  HashMap<String, Paint> paintsStub;
 
   @Before
   public void prepare() throws Exception {
-    HashMap<String, Paint> paintsStub = new HashMap<>();
+    paintsStub = new HashMap<>();
     paintsStub.put("innerCircle", paintMock);
     paintsStub.put("outerCircle", paintMock);
     paintsStub.put("number", paintMock);
@@ -64,19 +64,6 @@ public class FocusElementHighlightTest {
   }
 
   @Test
-  public void followsCorrectStepsToUpdateCoordinates() throws Exception {
-    mockStatic(OffsetHelper.class);
-
-    FocusElementHighlight elementSpy = spy(testSubject);
-    elementSpy.updateWithNewCoordinates();
-
-    verifyStatic(OffsetHelper.class, times(1));
-    OffsetHelper.getYOffset(any(View.class));
-
-    verifyPrivate(elementSpy, times(1)).invoke("setCoordinates");
-  }
-
-  @Test
   public void setPaintsWorksProperly() {
     HashMap<String, Paint> testPaintsStub = new HashMap<>();
     testPaintsStub.put("test", paintMock);
@@ -89,7 +76,22 @@ public class FocusElementHighlightTest {
   }
 
   @Test
+  public void drawElementHighlightDoesNothingWhenEventSourceIsNull() {
+    testSubject = new FocusElementHighlight(null, paintsStub, 10, 10, viewMock);
+    testSubject.drawElementHighlight(canvasMock);
+    verifyNoInteractions(canvasMock);
+  }
+
+  @Test
+  public void drawElementHighlightDoesNothingWhenEventSourceRefreshDoesNotWork() {
+    when(accessibilityNodeInfoMock.refresh()).thenReturn(false);
+    testSubject.drawElementHighlight(canvasMock);
+    verifyNoInteractions(canvasMock);
+  }
+
+  @Test
   public void drawElementHighlightCallsAllRelevantDrawMethods() throws Exception {
+    when(accessibilityNodeInfoMock.refresh()).thenReturn(true);
     FocusElementHighlight elementSpy = spy(testSubject);
     elementSpy.drawElementHighlight(canvasMock);
     verifyPrivate(elementSpy, times(1))

--- a/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/FocusVisualizerTest.java
+++ b/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/FocusVisualizerTest.java
@@ -4,6 +4,7 @@
 package com.microsoft.accessibilityinsightsforandroidservice;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
 import static org.powermock.api.mockito.PowerMockito.spy;
 import static org.powermock.api.mockito.PowerMockito.verifyPrivate;
@@ -107,5 +108,11 @@ public class FocusVisualizerTest {
     Assert.assertEquals(resultingHighlightList.size(), 0);
     Assert.assertEquals(resultingLineList.size(), 0);
     Assert.assertEquals(resultingTabStopCount, 0);
+  }
+
+  @Test
+  public void refreshHighlightsCallsRedraw() {
+    testSubject.refreshHighlights();
+    verify(focusVisualizationCanvasMock).redraw();
   }
 }


### PR DESCRIPTION
#### Details

This uses the refresh method inside the draw method to determine whether it should draw anything at all (refresh returns false when element is not visible/on screen).

##### Motivation

feature work.


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: #0000
- [x] Added/updated relevant unit test(s)
- [x] Ran `./gradlew fastpass` from `AccessibilityInsightsForAndroidService`
- [x] PR title _AND_ final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`).
