### PR TITLE
feat(focus-mvp-android-device): last focused node is highlighted when focus visualization enabled

### DIFF
--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/FocusVisualizer.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/FocusVisualizer.java
@@ -3,7 +3,6 @@
 
 package com.microsoft.accessibilityinsightsforandroidservice;
 
-import android.view.accessibility.AccessibilityEvent;
 import android.view.accessibility.AccessibilityNodeInfo;
 import java.util.ArrayList;
 

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/FocusVisualizer.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/FocusVisualizer.java
@@ -28,10 +28,9 @@ public class FocusVisualizer {
     this.focusVisualizationCanvas.redraw();
   }
 
-  public void addNewFocusedElement(AccessibilityEvent event) {
+  public void addNewFocusedElement(AccessibilityNodeInfo eventSource) {
     tabStopCount++;
 
-    AccessibilityNodeInfo eventSource = event.getSource();
     AccessibilityNodeInfo previousEventSource = this.getPreviousEventSource();
 
     if (this.focusElementHighlights.size() > 0) {

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/FocusVisualizerController.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/FocusVisualizerController.java
@@ -14,6 +14,7 @@ public class FocusVisualizerController {
   private WindowManager windowManager;
   private LayoutParamGenerator layoutParamGenerator;
   private FocusVisualizationCanvas focusVisualizationCanvas;
+  private AccessibilityNodeInfo lastEventSource;
 
   public FocusVisualizerController(
       FocusVisualizer focusVisualizer,
@@ -32,11 +33,13 @@ public class FocusVisualizerController {
   }
 
   public void onFocusEvent(AccessibilityEvent event) {
+    lastEventSource = event.getSource();
+
     if (focusVisualizationStateManager.getState() == false) {
       return;
     }
 
-    focusVisualizer.addNewFocusedElement(event);
+    focusVisualizer.addNewFocusedElement(event.getSource());
   }
 
   public void onRedrawEvent(AccessibilityEvent event) {
@@ -73,6 +76,9 @@ public class FocusVisualizerController {
   }
 
   private void addFocusVisualizationToScreen() {
+    if (lastEventSource != null) {
+      focusVisualizer.addNewFocusedElement(lastEventSource);
+    }
     windowManager.addView(focusVisualizationCanvas, layoutParamGenerator.get());
   }
 

--- a/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/FocusVisualizerControllerTest.java
+++ b/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/FocusVisualizerControllerTest.java
@@ -126,8 +126,8 @@ public class FocusVisualizerControllerTest {
               listener.accept(true);
               return null;
             })
-            .when(focusVisualizationStateManagerMock)
-            .subscribe(any());
+        .when(focusVisualizationStateManagerMock)
+        .subscribe(any());
 
     doAnswer(
             invocation -> {
@@ -135,17 +135,17 @@ public class FocusVisualizerControllerTest {
               runnable.run();
               return null;
             })
-            .when(uiThreadRunner)
-            .run(any());
+        .when(uiThreadRunner)
+        .run(any());
 
     testSubject =
-            new FocusVisualizerController(
-                    focusVisualizerMock,
-                    focusVisualizationStateManagerMock,
-                    uiThreadRunner,
-                    windowManager,
-                    layoutParamGenerator,
-                    focusVisualizationCanvas);
+        new FocusVisualizerController(
+            focusVisualizerMock,
+            focusVisualizationStateManagerMock,
+            uiThreadRunner,
+            windowManager,
+            layoutParamGenerator,
+            focusVisualizationCanvas);
 
     verify(windowManager).addView(focusVisualizationCanvas, layoutParams);
   }
@@ -159,8 +159,8 @@ public class FocusVisualizerControllerTest {
               listener = invocation.getArgument(0);
               return null;
             })
-            .when(focusVisualizationStateManagerMock)
-            .subscribe(any());
+        .when(focusVisualizationStateManagerMock)
+        .subscribe(any());
 
     doAnswer(
             invocation -> {
@@ -168,17 +168,17 @@ public class FocusVisualizerControllerTest {
               runnable.run();
               return null;
             })
-            .when(uiThreadRunner)
-            .run(any());
+        .when(uiThreadRunner)
+        .run(any());
 
     testSubject =
-            new FocusVisualizerController(
-                    focusVisualizerMock,
-                    focusVisualizationStateManagerMock,
-                    uiThreadRunner,
-                    windowManager,
-                    layoutParamGenerator,
-                    focusVisualizationCanvas);
+        new FocusVisualizerController(
+            focusVisualizerMock,
+            focusVisualizationStateManagerMock,
+            uiThreadRunner,
+            windowManager,
+            layoutParamGenerator,
+            focusVisualizationCanvas);
 
     testSubject.onFocusEvent(accessibilityEventMock);
     listener.accept(true);

--- a/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/FocusVisualizerTest.java
+++ b/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/FocusVisualizerTest.java
@@ -10,9 +10,7 @@ import static org.powermock.api.mockito.PowerMockito.spy;
 import static org.powermock.api.mockito.PowerMockito.verifyPrivate;
 import static org.powermock.api.mockito.PowerMockito.whenNew;
 
-import android.view.accessibility.AccessibilityEvent;
 import android.view.accessibility.AccessibilityNodeInfo;
-
 import java.util.ArrayList;
 import org.junit.Assert;
 import org.junit.Before;
@@ -30,8 +28,7 @@ public class FocusVisualizerTest {
 
   @Mock FocusVisualizerStyles focusVisualizerStylesMock;
   @Mock FocusVisualizationCanvas focusVisualizationCanvasMock;
-  @Mock
-  AccessibilityNodeInfo accessibilityEventMock;
+  @Mock AccessibilityNodeInfo accessibilityEventMock;
   @Mock FocusElementHighlight focusElementHighlightMock;
   @Mock FocusElementLine focusElementLineMock;
 

--- a/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/FocusVisualizerTest.java
+++ b/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/FocusVisualizerTest.java
@@ -11,6 +11,8 @@ import static org.powermock.api.mockito.PowerMockito.verifyPrivate;
 import static org.powermock.api.mockito.PowerMockito.whenNew;
 
 import android.view.accessibility.AccessibilityEvent;
+import android.view.accessibility.AccessibilityNodeInfo;
+
 import java.util.ArrayList;
 import org.junit.Assert;
 import org.junit.Before;
@@ -28,7 +30,8 @@ public class FocusVisualizerTest {
 
   @Mock FocusVisualizerStyles focusVisualizerStylesMock;
   @Mock FocusVisualizationCanvas focusVisualizationCanvasMock;
-  @Mock AccessibilityEvent accessibilityEventMock;
+  @Mock
+  AccessibilityNodeInfo accessibilityEventMock;
   @Mock FocusElementHighlight focusElementHighlightMock;
   @Mock FocusElementLine focusElementLineMock;
 


### PR DESCRIPTION
#### Details

Keeps track of the last event source to then use for highlighting when focus visualization is enabled.

##### Motivation

feature work

##### Context

Changed some interactions between classes since we cannot store the AccessibilityEvent but can store the AccessibilityNodeInfo underlying it.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: #0000
- [x] Added/updated relevant unit test(s)
- [x] Ran `./gradlew fastpass` from `AccessibilityInsightsForAndroidService`
- [x] PR title _AND_ final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`).
