### PR TITLE
feat(focus-mvp-android-device): current focus element highlight transparent inner circle

### DIFF
--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/FocusElementHighlight.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/FocusElementHighlight.java
@@ -20,6 +20,7 @@ public class FocusElementHighlight {
   private HashMap<String, Paint> paints;
   private Rect rect;
   private View view;
+  private boolean isCurrentElement;
   private static final String TAG = "FocusElementHighlight";
 
   public FocusElementHighlight(
@@ -34,6 +35,7 @@ public class FocusElementHighlight {
     this.radius = radius;
     this.rect = new Rect();
     this.paints = currentPaints;
+    this.isCurrentElement = true;
   }
 
   private void setCoordinates() {
@@ -54,10 +56,22 @@ public class FocusElementHighlight {
 
     this.updateWithNewCoordinates();
 
-    this.drawInnerCircle(
-        this.xCoordinate, this.yCoordinate, this.radius, this.paints.get("innerCircle"), canvas);
-    this.drawNumberInCircle(
-        this.xCoordinate, this.yCoordinate, this.tabStopCount, this.paints.get("number"), canvas);
+    if (!isCurrentElement) {
+      this.drawInnerCircle(
+          this.xCoordinate, this.yCoordinate, this.radius, this.paints.get("innerCircle"), canvas);
+      this.drawNumberInCircle(
+          this.xCoordinate, this.yCoordinate, this.tabStopCount, this.paints.get("number"), canvas);
+    }
+
+    if (isCurrentElement) {
+      this.drawInnerCircle(
+          this.xCoordinate,
+          this.yCoordinate,
+          this.radius,
+          this.paints.get("transparentInnerCircle"),
+          canvas);
+    }
+
     this.drawOuterCircle(
         this.xCoordinate, this.yCoordinate, this.radius, this.paints.get("outerCircle"), canvas);
   }
@@ -83,6 +97,10 @@ public class FocusElementHighlight {
 
   public void setPaints(HashMap<String, Paint> paints) {
     this.paints = paints;
+  }
+
+  public void setAsNonCurrentElement() {
+    this.isCurrentElement = false;
   }
 
   public AccessibilityNodeInfo getEventSource() {

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/FocusElementHighlight.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/FocusElementHighlight.java
@@ -56,13 +56,6 @@ public class FocusElementHighlight {
 
     this.updateWithNewCoordinates();
 
-    if (!isCurrentElement) {
-      this.drawInnerCircle(
-          this.xCoordinate, this.yCoordinate, this.radius, this.paints.get("innerCircle"), canvas);
-      this.drawNumberInCircle(
-          this.xCoordinate, this.yCoordinate, this.tabStopCount, this.paints.get("number"), canvas);
-    }
-
     if (isCurrentElement) {
       this.drawInnerCircle(
           this.xCoordinate,
@@ -70,6 +63,11 @@ public class FocusElementHighlight {
           this.radius,
           this.paints.get("transparentInnerCircle"),
           canvas);
+    } else {
+      this.drawInnerCircle(
+          this.xCoordinate, this.yCoordinate, this.radius, this.paints.get("innerCircle"), canvas);
+      this.drawNumberInCircle(
+          this.xCoordinate, this.yCoordinate, this.tabStopCount, this.paints.get("number"), canvas);
     }
 
     this.drawOuterCircle(

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/FocusVisualizer.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/FocusVisualizer.java
@@ -58,6 +58,7 @@ public class FocusVisualizer {
   }
 
   private void setPreviousElementHighlightNonCurrent(FocusElementHighlight focusElementHighlight) {
+    focusElementHighlight.setAsNonCurrentElement();
     focusElementHighlight.setPaints(this.styles.getNonCurrentElementPaints());
   }
 

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/FocusVisualizerStyles.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/FocusVisualizerStyles.java
@@ -6,6 +6,8 @@ package com.microsoft.accessibilityinsightsforandroidservice;
 import android.graphics.Color;
 import android.graphics.DashPathEffect;
 import android.graphics.Paint;
+import android.graphics.PorterDuff;
+import android.graphics.PorterDuffXfermode;
 import java.util.HashMap;
 
 public class FocusVisualizerStyles {
@@ -17,6 +19,7 @@ public class FocusVisualizerStyles {
   private Paint numberPaint;
   private Paint currentBackgroundLinePaint;
   private Paint nonCurrentBackgroundLinePaint;
+  private Paint transparentInnerCirclePaint;
 
   private HashMap<String, Paint> currentElementPaints;
   private HashMap<String, Paint> nonCurrentElementPaints;
@@ -34,6 +37,7 @@ public class FocusVisualizerStyles {
     this.setNonCurrentOuterCirclePaint();
     this.setCurrentBackgroundLinePaint();
     this.setNonCurrentBackgroundLinePaint();
+    this.setTransparentInnerCirclePaint();
 
     this.setCurrentElementPaints();
     this.setNonCurrentElementPaints();
@@ -46,6 +50,7 @@ public class FocusVisualizerStyles {
     this.currentElementPaints.put("outerCircle", this.currentOuterCirclePaint);
     this.currentElementPaints.put("innerCircle", this.innerCirclePaint);
     this.currentElementPaints.put("number", this.numberPaint);
+    this.currentElementPaints.put("transparentInnerCircle", this.transparentInnerCirclePaint);
   }
 
   public HashMap<String, Paint> getCurrentElementPaints() {
@@ -140,5 +145,12 @@ public class FocusVisualizerStyles {
     this.nonCurrentBackgroundLinePaint.setStyle(Paint.Style.STROKE);
     this.nonCurrentBackgroundLinePaint.setColor(Color.WHITE);
     this.nonCurrentBackgroundLinePaint.setStrokeWidth(12);
+  }
+
+  private void setTransparentInnerCirclePaint() {
+    this.transparentInnerCirclePaint = new Paint();
+    this.transparentInnerCirclePaint.setStyle(Paint.Style.FILL);
+    this.transparentInnerCirclePaint.setColor(Color.TRANSPARENT);
+    this.transparentInnerCirclePaint.setXfermode(new PorterDuffXfermode(PorterDuff.Mode.CLEAR));
   }
 }

--- a/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/FocusElementHighlightTest.java
+++ b/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/FocusElementHighlightTest.java
@@ -49,6 +49,7 @@ public class FocusElementHighlightTest {
     paintsStub.put("innerCircle", paintMock);
     paintsStub.put("outerCircle", paintMock);
     paintsStub.put("number", paintMock);
+    paintsStub.put("transparentInnerCircle", paintMock);
 
     when(viewMock.getResources()).thenReturn(resourcesMock);
     whenNew(Rect.class).withNoArguments().thenReturn(rectMock);
@@ -90,7 +91,22 @@ public class FocusElementHighlightTest {
   }
 
   @Test
-  public void drawElementHighlightCallsAllRelevantDrawMethods() throws Exception {
+  public void drawElementHighlightCallsAllRelevantDrawMethodsForCurrentElement() throws Exception {
+    when(accessibilityNodeInfoMock.refresh()).thenReturn(true);
+    FocusElementHighlight elementSpy = spy(testSubject);
+    elementSpy.drawElementHighlight(canvasMock);
+    verifyPrivate(elementSpy, times(1))
+        .invoke(
+            "drawInnerCircle", anyInt(), anyInt(), anyInt(), any(Paint.class), any(Canvas.class));
+    verifyPrivate(elementSpy, times(1))
+        .invoke(
+            "drawOuterCircle", anyInt(), anyInt(), anyInt(), any(Paint.class), any(Canvas.class));
+  }
+
+  @Test
+  public void drawElementHighlightCallsAllRelevantDrawMethodsForNonCurrentElement()
+      throws Exception {
+    testSubject.setAsNonCurrentElement();
     when(accessibilityNodeInfoMock.refresh()).thenReturn(true);
     FocusElementHighlight elementSpy = spy(testSubject);
     elementSpy.drawElementHighlight(canvasMock);
@@ -113,5 +129,11 @@ public class FocusElementHighlightTest {
   @Test
   public void getEventSourceReturnsAccessibilityNodeInfo() {
     Assert.assertEquals(testSubject.getEventSource(), accessibilityNodeInfoMock);
+  }
+
+  @Test
+  public void setAsNonCurrentElementFunctionsAsExpected() {
+    testSubject.setAsNonCurrentElement();
+    Assert.assertEquals(Whitebox.getInternalState(testSubject, "isCurrentElement"), false);
   }
 }

--- a/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/FocusVisualizerStylesTest.java
+++ b/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/FocusVisualizerStylesTest.java
@@ -36,6 +36,7 @@ public class FocusVisualizerStylesTest {
     Assert.assertNotNull(paints.get("outerCircle"));
     Assert.assertNotNull(paints.get("innerCircle"));
     Assert.assertNotNull(paints.get("number"));
+    Assert.assertNotNull(paints.get("transparentInnerCircle"));
   }
 
   @Test


### PR DESCRIPTION
#### Details

This moves the visualization of the current focus element highlight in line with the spec, by ensuring that the inner circle is transparent.

##### Motivation

Fixes current element highlight inner-circle transparency


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] Addresses an existing issue: #0000
- [x] Added/updated relevant unit test(s)
- [x] Ran `./gradlew fastpass` from `AccessibilityInsightsForAndroidService`
- [x] PR title _AND_ final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`).
