### PR TITLE
feat(focus-mvp-android-device): silence focus events after a recent orientation change

### DIFF
--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/AccessibilityInsightsForAndroidService.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/AccessibilityInsightsForAndroidService.java
@@ -116,7 +116,7 @@ public class AccessibilityInsightsForAndroidService extends AccessibilityService
     LayoutParamGenerator layoutParamGenerator = new LayoutParamGenerator(this::getRealDisplayMetrics);
     focusVisualizationCanvas = new FocusVisualizationCanvas(this);
     focusVisualizer = new FocusVisualizer(new FocusVisualizerStyles(), focusVisualizationCanvas);
-    focusVisualizerController = new FocusVisualizerController(focusVisualizer, focusVisualizationStateManager, new UIThreadRunner(), windowManager, layoutParamGenerator, focusVisualizationCanvas);
+    focusVisualizerController = new FocusVisualizerController(focusVisualizer, focusVisualizationStateManager, new UIThreadRunner(), windowManager, layoutParamGenerator, focusVisualizationCanvas, new DateProvider());
     accessibilityEventDispatcher = new AccessibilityEventDispatcher();
     deviceOrientationHandler = new DeviceOrientationHandler(getResources().getConfiguration().orientation);
 

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/DateProvider.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/DateProvider.java
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package com.microsoft.accessibilityinsightsforandroidservice;
+
+import java.util.Date;
+
+public class DateProvider {
+  public Date get() {
+    return new Date();
+  }
+}

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/FocusVisualizerController.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/FocusVisualizerController.java
@@ -6,6 +6,7 @@ package com.microsoft.accessibilityinsightsforandroidservice;
 import android.view.WindowManager;
 import android.view.accessibility.AccessibilityEvent;
 import android.view.accessibility.AccessibilityNodeInfo;
+import java.util.Date;
 
 public class FocusVisualizerController {
   private FocusVisualizer focusVisualizer;
@@ -15,6 +16,9 @@ public class FocusVisualizerController {
   private LayoutParamGenerator layoutParamGenerator;
   private FocusVisualizationCanvas focusVisualizationCanvas;
   private AccessibilityNodeInfo lastEventSource;
+  private DateProvider dateProvider;
+  private Date lastOrientationChange;
+  private long maximumOrientationChangeDelay = 1000;
 
   public FocusVisualizerController(
       FocusVisualizer focusVisualizer,
@@ -22,20 +26,23 @@ public class FocusVisualizerController {
       UIThreadRunner uiThreadRunner,
       WindowManager windowManager,
       LayoutParamGenerator layoutParamGenerator,
-      FocusVisualizationCanvas focusVisualizationCanvas) {
+      FocusVisualizationCanvas focusVisualizationCanvas,
+      DateProvider dateProvider) {
     this.focusVisualizer = focusVisualizer;
     this.focusVisualizationStateManager = focusVisualizationStateManager;
     this.uiThreadRunner = uiThreadRunner;
     this.windowManager = windowManager;
     this.layoutParamGenerator = layoutParamGenerator;
     this.focusVisualizationCanvas = focusVisualizationCanvas;
+    this.dateProvider = dateProvider;
     this.focusVisualizationStateManager.subscribe(this::onFocusVisualizationStateChange);
+    this.lastOrientationChange = dateProvider.get();
   }
 
   public void onFocusEvent(AccessibilityEvent event) {
     lastEventSource = event.getSource();
-
-    if (focusVisualizationStateManager.getState() == false) {
+    if (focusVisualizationStateManager.getState() == false
+        || ignoreFocusEventDueToRecentOrientationChange()) {
       return;
     }
 
@@ -62,7 +69,7 @@ public class FocusVisualizerController {
     if (focusVisualizationStateManager.getState() == false) {
       return;
     }
-
+    lastOrientationChange = new Date();
     windowManager.updateViewLayout(focusVisualizationCanvas, layoutParamGenerator.get());
     focusVisualizer.resetVisualizations();
   }
@@ -85,5 +92,13 @@ public class FocusVisualizerController {
   private void removeFocusVisualizationToScreen() {
     focusVisualizer.resetVisualizations();
     windowManager.removeView(focusVisualizationCanvas);
+  }
+
+  private boolean ignoreFocusEventDueToRecentOrientationChange() {
+    Date currentTime = dateProvider.get();
+    long cur = currentTime.getTime();
+    long last = lastOrientationChange.getTime();
+    long timeSinceLastOrientationChange = cur - last;
+    return timeSinceLastOrientationChange < maximumOrientationChangeDelay;
   }
 }

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/FocusVisualizerController.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/FocusVisualizerController.java
@@ -69,7 +69,7 @@ public class FocusVisualizerController {
     if (focusVisualizationStateManager.getState() == false) {
       return;
     }
-    lastOrientationChange = new Date();
+    lastOrientationChange = dateProvider.get();
     windowManager.updateViewLayout(focusVisualizationCanvas, layoutParamGenerator.get());
     focusVisualizer.resetVisualizations();
   }


### PR DESCRIPTION
#### Details

Will ignore focus events for focus visualization purposes after orientation has been changed for 1 second.

##### Motivation

feature work.

##### Context

Using a new class known as Date Provider, a pattern we've used before, so that I don't have to use static mocks which are a bit troublesome.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: #0000
- [x] Added/updated relevant unit test(s)
- [x] Ran `./gradlew fastpass` from `AccessibilityInsightsForAndroidService`
- [x] PR title _AND_ final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`).
