### PR TITLE
chore: replace jcenter with mavenCentral

### DIFF
--- a/AccessibilityInsightsForAndroidService/build.gradle
+++ b/AccessibilityInsightsForAndroidService/build.gradle
@@ -5,7 +5,7 @@
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
         exclusiveContent {
             forRepository {
                 google()
@@ -14,8 +14,16 @@ buildscript {
                 includeGroupByRegex("^androidx(\$|\\..*)")
                 includeGroupByRegex("^com\\.android(\$|\\..*)")
                 // Note: not all com.google.* cases come from google(), several are published
-                // to jcenter/mavenCentral only (eg, gson, protobuf, findbugs, guava, jimfs)
+                // to mavenCentral only (eg, gson, protobuf, findbugs, guava, jimfs)
                 includeGroup("com.google.test.platform")
+            }
+        }
+        exclusiveContent {
+            forRepository {
+                gradlePluginPortal()
+            }
+            filter {
+                includeGroup("org.jetbrains.trove4j")
             }
         }
     }
@@ -33,7 +41,7 @@ plugins {
 
 allprojects {
     repositories {
-        jcenter()
+        mavenCentral()
         exclusiveContent {
             forRepository {
                 google()
@@ -42,8 +50,16 @@ allprojects {
                 includeGroupByRegex("^androidx(\$|\\..*)")
                 includeGroupByRegex("^com\\.android(\$|\\..*)")
                 // Note: not all com.google.* cases come from google(), several are published
-                // to jcenter/mavenCentral only (eg, gson, protobuf, findbugs, guava, jimfs)
+                // to mavenCentral only (eg, gson, protobuf, findbugs, guava, jimfs)
                 includeGroup("com.google.test.platform")
+            }
+        }
+        exclusiveContent {
+            forRepository {
+                gradlePluginPortal()
+            }
+            filter {
+                includeGroup("org.jetbrains.trove4j")
             }
         }
     }


### PR DESCRIPTION
#### Details

This PR changes which repository we download most dependencies on from JCenter ([which is being shut down on May 1 2021](https://developer.android.com/studio/build/jcenter-migration)) to Maven Central.

There is one dependency (`org.jetbrains.trove4j:trove4j`) which is present on JCenter but not Maven Central (see [these](https://stackoverflow.com/q/49573157/2825668) [two](https://stackoverflow.com/q/45818613/2825668) StackOverflow threads). [Based on those threads](https://stackoverflow.com/a/66168563/2825668), the most reputable location where this dependency is published appears to be the Gradle Plugins repository, which in Gradle 6 is officially aliased as `gradlePluginPortal()`.

See #70 for context on why we use an `exclusiveContent` directive for this for this, rather than just a bare `gradlePluginPortal()` directive like the StackOverflow answer suggests.

##### Motivation

Avoid build breaks after JCenter shuts down in a few weeks

##### Context

* [Deprecation announcement from JFrog](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/)
* [Deprecation announcement on android.com](https://developer.android.com/studio/build/jcenter-migration)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] Addresses an existing issue: #0000
- [n/a] Added/updated relevant unit test(s)
- [x] Ran `./gradlew fastpass` from `AccessibilityInsightsForAndroidService`
- [x] PR title _AND_ final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`).
