### PR TITLE
feat(google-rules-mvp-service): Introduce ResultSerializer and use in ResultRequestFulfiller

### DIFF
--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/RequestHandlerFactory.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/RequestHandlerFactory.java
@@ -14,6 +14,7 @@ public class RequestHandlerFactory {
   private final DeviceConfigFactory deviceConfigFactory;
   private final RequestHandlerImplFactory requestHandlerImplFactory;
   private final FocusVisualizationStateManager focusVisualizationStateManager;
+  private final ResultSerializer resultSerializer;
 
   public RequestHandlerFactory(
       ScreenshotController screenshotController,
@@ -22,7 +23,8 @@ public class RequestHandlerFactory {
       AxeScanner axeScanner,
       DeviceConfigFactory deviceConfigFactory,
       RequestHandlerImplFactory requestHandlerImplFactory,
-      FocusVisualizationStateManager focusVisualizationStateManager) {
+      FocusVisualizationStateManager focusVisualizationStateManager,
+      ResultSerializer resultSerializer) {
     this.screenshotController = screenshotController;
     this.axeScanner = axeScanner;
     this.rootNodeFinder = rootNodeFinder;
@@ -30,6 +32,7 @@ public class RequestHandlerFactory {
     this.deviceConfigFactory = deviceConfigFactory;
     this.requestHandlerImplFactory = requestHandlerImplFactory;
     this.focusVisualizationStateManager = focusVisualizationStateManager;
+    this.resultSerializer = resultSerializer;
   }
 
   public RequestHandler createHandlerForRequest(
@@ -39,7 +42,12 @@ public class RequestHandlerFactory {
       if (requestString.startsWith("GET /AccessibilityInsights/result ")) {
         ResultRequestFulfiller resultRequestFulfiller =
             new ResultRequestFulfiller(
-                responseWriter, rootNodeFinder, eventHelper, axeScanner, screenshotController);
+                responseWriter,
+                rootNodeFinder,
+                eventHelper,
+                axeScanner,
+                screenshotController,
+                resultSerializer);
         return requestHandlerImplFactory.createRequestHandler(
             socketHolder,
             resultRequestFulfiller,

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ResponseThreadFactory.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ResponseThreadFactory.java
@@ -26,7 +26,8 @@ public class ResponseThreadFactory {
             axeScanner,
             deviceConfigFactory,
             new RequestHandlerImplFactory(),
-            focusVisualizationStateManager);
+            focusVisualizationStateManager,
+            new ResultSerializer());
   }
 
   public ResponseThread createResponseThread(Socket socket) {

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ResultRequestFulfiller.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ResultRequestFulfiller.java
@@ -13,18 +13,21 @@ public class ResultRequestFulfiller implements RequestFulfiller {
   private final ResponseWriter responseWriter;
   private final AxeScanner axeScanner;
   private final ScreenshotController screenshotController;
+  private final ResultSerializer resultSerializer;
 
   public ResultRequestFulfiller(
       ResponseWriter responseWriter,
       RootNodeFinder rootNodeFinder,
       EventHelper eventHelper,
       AxeScanner axeScanner,
-      ScreenshotController screenshotController) {
+      ScreenshotController screenshotController,
+      ResultSerializer resultSerializer) {
     this.responseWriter = responseWriter;
     this.rootNodeFinder = rootNodeFinder;
     this.eventHelper = eventHelper;
     this.axeScanner = axeScanner;
     this.screenshotController = screenshotController;
+    this.resultSerializer = resultSerializer;
   }
 
   public void fulfillRequest(RunnableFunction onRequestFulfilled) {
@@ -64,6 +67,8 @@ public class ResultRequestFulfiller implements RequestFulfiller {
     if (result == null) {
       throw new ScanException("Scanner returned no data");
     }
-    return result.toJson();
+
+    resultSerializer.addAxeResult(result);
+    return resultSerializer.generateResultJson();
   }
 }

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ResultSerializer.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ResultSerializer.java
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package com.microsoft.accessibilityinsightsforandroidservice;
+
+import com.deque.axe.android.AxeResult;
+
+public class ResultSerializer {
+  private AxeResult axeResult;
+
+  public ResultSerializer() {}
+
+  public void addAxeResult(AxeResult axeResult) {
+    this.axeResult = axeResult;
+  }
+
+  public String generateResultJson() {
+    return this.axeResult.toJson();
+  }
+}

--- a/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/RequestHandlerFactoryTest.java
+++ b/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/RequestHandlerFactoryTest.java
@@ -27,6 +27,7 @@ public class RequestHandlerFactoryTest {
   @Mock ResponseWriter responseWriter;
   @Mock RequestHandlerImplFactory requestHandlerImplFactory;
   @Mock FocusVisualizationStateManager focusVisualizationStateManager;
+  @Mock ResultSerializer resultSerializer;
 
   RequestHandlerFactory testSubject;
 
@@ -40,7 +41,8 @@ public class RequestHandlerFactoryTest {
             axeScanner,
             deviceConfigFactory,
             requestHandlerImplFactory,
-            focusVisualizationStateManager);
+            focusVisualizationStateManager,
+            resultSerializer);
   }
 
   @Test

--- a/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/ResultRequestFulfillerTest.java
+++ b/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/ResultRequestFulfillerTest.java
@@ -39,6 +39,7 @@ public class ResultRequestFulfillerTest {
   @Mock AccessibilityNodeInfo rootNode;
   @Mock AxeResult axeResultMock;
   @Mock RunnableFunction onRequestFulfilledMock;
+  @Mock ResultSerializer resultSerializer;
 
   final String scanResultJson = "axe scan result";
 
@@ -55,7 +56,12 @@ public class ResultRequestFulfillerTest {
         .getScreenshotWithMediaProjection(any());
     testSubject =
         new ResultRequestFulfiller(
-            responseWriter, rootNodeFinder, eventHelper, axeScanner, screenshotController);
+            responseWriter,
+            rootNodeFinder,
+            eventHelper,
+            axeScanner,
+            screenshotController,
+            resultSerializer);
   }
 
   @Test
@@ -163,6 +169,15 @@ public class ResultRequestFulfillerTest {
     verify(sourceNode, never()).recycle();
   }
 
+  @Test
+  public void addsAxeResultToSerializer() {
+    setupSuccessfulRequest();
+
+    testSubject.fulfillRequest(onRequestFulfilledMock);
+
+    verify(resultSerializer, times(1)).addAxeResult(axeResultMock);
+  }
+
   private void setupSuccessfulRequest() {
     when(eventHelper.claimLastSource()).thenReturn(sourceNode);
     when(rootNodeFinder.getRootNodeFromSource(any())).thenReturn(rootNode);
@@ -171,7 +186,7 @@ public class ResultRequestFulfillerTest {
     } catch (ViewChangedException e) {
       Assert.fail(e.getMessage());
     }
-    when(axeResultMock.toJson()).thenReturn(scanResultJson);
+    when(resultSerializer.generateResultJson()).thenReturn(scanResultJson);
   }
 
   private void verifyOnRequestFulfilledCalled() {

--- a/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/ResultSerializerTest.java
+++ b/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/ResultSerializerTest.java
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package com.microsoft.accessibilityinsightsforandroidservice;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.deque.axe.android.AxeResult;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ResultSerializerTest {
+
+  @Mock AxeResult axeResultMock;
+
+  ResultSerializer testSubject;
+
+  final String scanResultJson = "axe scan result";
+
+  @Before
+  public void prepare() {
+    testSubject = new ResultSerializer();
+  }
+
+  @Test
+  public void resultSerializerExists() {
+    Assert.assertNotNull(testSubject);
+  }
+
+  @Test
+  public void generatesExpectedJson() {
+    when(axeResultMock.toJson()).thenReturn(scanResultJson);
+
+    testSubject.addAxeResult(axeResultMock);
+    String generatedJson = testSubject.generateResultJson();
+
+    verify(axeResultMock, times(1)).toJson();
+    Assert.assertEquals(generatedJson, scanResultJson);
+  }
+}


### PR DESCRIPTION
#### Details
In preparation for adding ATFA results, this PR introduces `ResultSerializer` and uses it to generate the response string in `ResultRequestFulfiller`. This has no functional impact--for now, `ResultSerializer` is just a wrapper around `AxeResult` that calls `toJson()`.

##### Motivation
Ultimately, we need a way to return AxeResults, ATFA results, and ATFA rules serialized alongside each other. This PR introduces the layer of abstraction where this serialization will take place.

##### Context
Out of scope: adding any new results to the response of `ResultRequestFulfiller`. Future PRs will expand upon `ResultSerializer` such that it returns additional data.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] Addresses an existing issue: #0000
- [x] Added/updated relevant unit test(s)
- [x] Ran `./gradlew fastpass` from `AccessibilityInsightsForAndroidService`
- [x] PR title _AND_ final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`).
