### PR TITLE
feat(google-rules-mvp-service): Create ATFAScanner

### DIFF
--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ATFAScanner.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ATFAScanner.java
@@ -5,7 +5,6 @@ package com.microsoft.accessibilityinsightsforandroidservice;
 
 import android.content.Context;
 import android.view.accessibility.AccessibilityNodeInfo;
-
 import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckPreset;
 import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResult;
 import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils;
@@ -13,41 +12,47 @@ import com.google.android.apps.common.testing.accessibility.framework.Accessibil
 import com.google.android.apps.common.testing.accessibility.framework.AccessibilityHierarchyCheckResult;
 import com.google.android.apps.common.testing.accessibility.framework.Parameters;
 import com.google.android.apps.common.testing.accessibility.framework.uielement.AccessibilityHierarchyAndroid;
-import com.google.android.apps.common.testing.accessibility.framework.uielement.ViewHierarchyElementAndroid;
 import com.google.android.apps.common.testing.accessibility.framework.utils.contrast.BitmapImage;
 import com.google.common.collect.ImmutableSet;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 
 public class ATFAScanner {
-    private final Context context;
+  private final Context context;
 
-    public ATFAScanner(Context context) {
-        this.context = context;
+  public ATFAScanner(Context context) {
+    this.context = context;
+  }
+
+  public List<AccessibilityHierarchyCheckResult> scanWithATFA(
+      AccessibilityNodeInfo rootNode, BitmapImage screenshot) {
+    Parameters parameters = new Parameters();
+    parameters.setSaveViewImages(true);
+    parameters.putCustomTouchTargetSize(44); // default is 48 but min size as defined by WCAG is 44
+    parameters.putScreenCapture(screenshot);
+
+    ImmutableSet<AccessibilityHierarchyCheck> checks =
+        AccessibilityCheckPreset.getAccessibilityHierarchyChecksForPreset(
+            AccessibilityCheckPreset.LATEST);
+    AccessibilityHierarchyAndroid hierarchy =
+        AccessibilityHierarchyAndroid.newBuilder(rootNode, this.context).build();
+    List<AccessibilityHierarchyCheckResult> results = new ArrayList<>();
+
+    for (AccessibilityHierarchyCheck check : checks) {
+      results.addAll(check.runCheckOnHierarchy(hierarchy, null, parameters));
     }
 
-    public List<AccessibilityHierarchyCheckResult> scanWithATFA(AccessibilityNodeInfo rootNode, BitmapImage screenshot) {
-        Parameters parameters = new Parameters();
-        parameters.setSaveViewImages(true);
-        parameters.putCustomTouchTargetSize(44); // default is 48 but min size as defined by WCAG is 44
-        parameters.putScreenCapture(screenshot);
+    AccessibilityCheckResult.AccessibilityCheckResultType[] relevantTypes = {
+      AccessibilityCheckResult.AccessibilityCheckResultType.ERROR,
+      AccessibilityCheckResult.AccessibilityCheckResultType.INFO,
+      AccessibilityCheckResult.AccessibilityCheckResultType.WARNING,
+      AccessibilityCheckResult.AccessibilityCheckResultType.RESOLVED,
+      AccessibilityCheckResult.AccessibilityCheckResultType.NOT_RUN
+    };
 
-        ImmutableSet<AccessibilityHierarchyCheck> checks =
-                AccessibilityCheckPreset.getAccessibilityHierarchyChecksForPreset(
-                        AccessibilityCheckPreset.LATEST);
-        AccessibilityHierarchyAndroid hierarchy = AccessibilityHierarchyAndroid.newBuilder(rootNode, this.context).build();
-        List<AccessibilityHierarchyCheckResult> results = new ArrayList<>();
-
-        for (AccessibilityHierarchyCheck check : checks) {
-            results.addAll(check.runCheckOnHierarchy(hierarchy, null, parameters));
-        }
-
-        AccessibilityCheckResult.AccessibilityCheckResultType[] relevantTypes = {AccessibilityCheckResult.AccessibilityCheckResultType.ERROR, AccessibilityCheckResult.AccessibilityCheckResultType.INFO,
-            AccessibilityCheckResult.AccessibilityCheckResultType.WARNING, AccessibilityCheckResult.AccessibilityCheckResultType.RESOLVED, AccessibilityCheckResult.AccessibilityCheckResultType.NOT_RUN};
-
-        return AccessibilityCheckResultUtils.getResultsForTypes(results, new HashSet<>(Arrays.asList(relevantTypes)));
-    }
+    return AccessibilityCheckResultUtils.getResultsForTypes(
+        results, new HashSet<>(Arrays.asList(relevantTypes)));
+  }
 }

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ATFAScanner.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ATFAScanner.java
@@ -32,7 +32,7 @@ public class ATFAScanner {
     public List<AccessibilityHierarchyCheckResult> scanWithATFA(AccessibilityNodeInfo rootNode, BitmapImage screenshot) {
         Parameters parameters = new Parameters();
         parameters.setSaveViewImages(true);
-        parameters.putCustomTouchTargetSize(44);
+        parameters.putCustomTouchTargetSize(44); // default is 48 but min size as defined by WCAG is 44
         parameters.putScreenCapture(screenshot);
 
         ImmutableSet<AccessibilityHierarchyCheck> checks =

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ATFAScanner.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ATFAScanner.java
@@ -21,6 +21,13 @@ import java.util.List;
 
 public class ATFAScanner {
   private final Context context;
+  private final AccessibilityCheckResult.AccessibilityCheckResultType[] relevantResultTypes = {
+    AccessibilityCheckResult.AccessibilityCheckResultType.ERROR,
+    AccessibilityCheckResult.AccessibilityCheckResultType.INFO,
+    AccessibilityCheckResult.AccessibilityCheckResultType.WARNING,
+    AccessibilityCheckResult.AccessibilityCheckResultType.RESOLVED,
+    AccessibilityCheckResult.AccessibilityCheckResultType.NOT_RUN
+  };
 
   public ATFAScanner(Context context) {
     this.context = context;
@@ -44,15 +51,7 @@ public class ATFAScanner {
       results.addAll(check.runCheckOnHierarchy(hierarchy, null, parameters));
     }
 
-    AccessibilityCheckResult.AccessibilityCheckResultType[] relevantTypes = {
-      AccessibilityCheckResult.AccessibilityCheckResultType.ERROR,
-      AccessibilityCheckResult.AccessibilityCheckResultType.INFO,
-      AccessibilityCheckResult.AccessibilityCheckResultType.WARNING,
-      AccessibilityCheckResult.AccessibilityCheckResultType.RESOLVED,
-      AccessibilityCheckResult.AccessibilityCheckResultType.NOT_RUN
-    };
-
     return AccessibilityCheckResultUtils.getResultsForTypes(
-        results, new HashSet<>(Arrays.asList(relevantTypes)));
+        results, new HashSet<>(Arrays.asList(relevantResultTypes)));
   }
 }

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ATFAScanner.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ATFAScanner.java
@@ -39,15 +39,14 @@ public class ATFAScanner {
                 AccessibilityCheckPreset.getAccessibilityHierarchyChecksForPreset(
                         AccessibilityCheckPreset.LATEST);
         AccessibilityHierarchyAndroid hierarchy = AccessibilityHierarchyAndroid.newBuilder(rootNode, this.context).build();
-        // ViewHierarchyElementAndroid element = hierarchy.getActiveWindow().getRootView();
         List<AccessibilityHierarchyCheckResult> results = new ArrayList<>();
 
         for (AccessibilityHierarchyCheck check : checks) {
             results.addAll(check.runCheckOnHierarchy(hierarchy, null, parameters));
         }
 
-        AccessibilityCheckResult.AccessibilityCheckResultType[] relevantTypes = {AccessibilityCheckResult.AccessibilityCheckResultType.ERROR, AccessibilityCheckResult.AccessibilityCheckResultType.INFO, AccessibilityCheckResult.AccessibilityCheckResultType.WARNING, AccessibilityCheckResult.AccessibilityCheckResultType.RESOLVED,
-                AccessibilityCheckResult.AccessibilityCheckResultType.NOT_RUN};
+        AccessibilityCheckResult.AccessibilityCheckResultType[] relevantTypes = {AccessibilityCheckResult.AccessibilityCheckResultType.ERROR, AccessibilityCheckResult.AccessibilityCheckResultType.INFO,
+            AccessibilityCheckResult.AccessibilityCheckResultType.WARNING, AccessibilityCheckResult.AccessibilityCheckResultType.RESOLVED, AccessibilityCheckResult.AccessibilityCheckResultType.NOT_RUN};
 
         return AccessibilityCheckResultUtils.getResultsForTypes(results, new HashSet<>(Arrays.asList(relevantTypes)));
     }

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ATFAScanner.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ATFAScanner.java
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package com.microsoft.accessibilityinsightsforandroidservice;
+
+import android.content.Context;
+import android.view.accessibility.AccessibilityNodeInfo;
+
+import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckPreset;
+import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResult;
+import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils;
+import com.google.android.apps.common.testing.accessibility.framework.AccessibilityHierarchyCheck;
+import com.google.android.apps.common.testing.accessibility.framework.AccessibilityHierarchyCheckResult;
+import com.google.android.apps.common.testing.accessibility.framework.Parameters;
+import com.google.android.apps.common.testing.accessibility.framework.uielement.AccessibilityHierarchyAndroid;
+import com.google.android.apps.common.testing.accessibility.framework.uielement.ViewHierarchyElementAndroid;
+import com.google.android.apps.common.testing.accessibility.framework.utils.contrast.BitmapImage;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+
+public class ATFAScanner {
+    private final Context context;
+
+    public ATFAScanner(Context context) {
+        this.context = context;
+    }
+
+    public List<AccessibilityHierarchyCheckResult> scanWithATFA(AccessibilityNodeInfo rootNode, BitmapImage screenshot) {
+        Parameters parameters = new Parameters();
+        parameters.setSaveViewImages(true);
+        parameters.putCustomTouchTargetSize(44);
+        parameters.putScreenCapture(screenshot);
+
+        ImmutableSet<AccessibilityHierarchyCheck> checks =
+                AccessibilityCheckPreset.getAccessibilityHierarchyChecksForPreset(
+                        AccessibilityCheckPreset.LATEST);
+        AccessibilityHierarchyAndroid hierarchy = AccessibilityHierarchyAndroid.newBuilder(rootNode, this.context).build();
+        // ViewHierarchyElementAndroid element = hierarchy.getActiveWindow().getRootView();
+        List<AccessibilityHierarchyCheckResult> results = new ArrayList<>();
+
+        for (AccessibilityHierarchyCheck check : checks) {
+            results.addAll(check.runCheckOnHierarchy(hierarchy, null, parameters));
+        }
+
+        AccessibilityCheckResult.AccessibilityCheckResultType[] relevantTypes = {AccessibilityCheckResult.AccessibilityCheckResultType.ERROR, AccessibilityCheckResult.AccessibilityCheckResultType.INFO, AccessibilityCheckResult.AccessibilityCheckResultType.WARNING, AccessibilityCheckResult.AccessibilityCheckResultType.RESOLVED,
+                AccessibilityCheckResult.AccessibilityCheckResultType.NOT_RUN};
+
+        return AccessibilityCheckResultUtils.getResultsForTypes(results, new HashSet<>(Arrays.asList(relevantTypes)));
+    }
+}

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ATFAScannerFactory.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ATFAScannerFactory.java
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package com.microsoft.accessibilityinsightsforandroidservice;
+
+import android.content.Context;
+
+public class ATFAScannerFactory {
+  public static ATFAScanner createATFAScanner(Context context) {
+    return new ATFAScanner(context);
+  }
+}

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/AccessibilityInsightsForAndroidService.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/AccessibilityInsightsForAndroidService.java
@@ -31,6 +31,7 @@ public class AccessibilityInsightsForAndroidService extends AccessibilityService
   private static final String TAG = "AccessibilityInsightsForAndroidService";
   private static ServerThread ServerThread = null;
   private final AxeScanner axeScanner;
+  private final ATFAScanner atfaScanner;
   private final EventHelper eventHelper;
   private final DeviceConfigFactory deviceConfigFactory;
   private final OnScreenshotAvailableProvider onScreenshotAvailableProvider =
@@ -50,6 +51,7 @@ public class AccessibilityInsightsForAndroidService extends AccessibilityService
     deviceConfigFactory = new DeviceConfigFactory();
     axeScanner =
         AxeScannerFactory.createAxeScanner(deviceConfigFactory, this::getRealDisplayMetrics);
+    atfaScanner = ATFAScannerFactory.createATFAScanner(this);
     eventHelper = new EventHelper(new ThreadSafeSwapper<>());
   }
 

--- a/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/ATFAScannerFactoryTest.java
+++ b/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/ATFAScannerFactoryTest.java
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package com.microsoft.accessibilityinsightsforandroidservice;
+
+import android.content.Context;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ATFAScannerFactoryTest {
+  @Mock Context contextMock;
+
+  @Before
+  public void prepare() {}
+
+  @Test
+  public void atfaScannerExists() {
+    Assert.assertNotNull(
+        ATFAScannerFactory.createATFAScanner(contextMock));
+  }
+}

--- a/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/ATFAScannerFactoryTest.java
+++ b/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/ATFAScannerFactoryTest.java
@@ -4,7 +4,6 @@
 package com.microsoft.accessibilityinsightsforandroidservice;
 
 import android.content.Context;
-
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -21,7 +20,6 @@ public class ATFAScannerFactoryTest {
 
   @Test
   public void atfaScannerExists() {
-    Assert.assertNotNull(
-        ATFAScannerFactory.createATFAScanner(contextMock));
+    Assert.assertNotNull(ATFAScannerFactory.createATFAScanner(contextMock));
   }
 }

--- a/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/ATFAScannerTest.java
+++ b/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/ATFAScannerTest.java
@@ -3,7 +3,6 @@
 
 package com.microsoft.accessibilityinsightsforandroidservice;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
@@ -11,7 +10,6 @@ import static org.mockito.Mockito.when;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.view.accessibility.AccessibilityNodeInfo;
-
 import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckPreset;
 import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils;
 import com.google.android.apps.common.testing.accessibility.framework.AccessibilityHierarchyCheck;
@@ -20,7 +18,8 @@ import com.google.android.apps.common.testing.accessibility.framework.Parameters
 import com.google.android.apps.common.testing.accessibility.framework.uielement.AccessibilityHierarchyAndroid;
 import com.google.android.apps.common.testing.accessibility.framework.utils.contrast.BitmapImage;
 import com.google.common.collect.ImmutableSet;
-
+import java.util.Collections;
+import java.util.List;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -30,11 +29,12 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import java.util.Collections;
-import java.util.List;
-
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({AccessibilityCheckPreset.class, AccessibilityHierarchyAndroid.class, AccessibilityCheckResultUtils.class})
+@PrepareForTest({
+  AccessibilityCheckPreset.class,
+  AccessibilityHierarchyAndroid.class,
+  AccessibilityCheckResultUtils.class
+})
 public class ATFAScannerTest {
 
   @Mock Bitmap bitmapMock;
@@ -64,14 +64,18 @@ public class ATFAScannerTest {
 
   @Test
   public void scanWithATFAReturnsCorrectResult() throws ViewChangedException {
-    when(AccessibilityCheckPreset.getAccessibilityHierarchyChecksForPreset(AccessibilityCheckPreset.LATEST)).thenReturn(ImmutableSet.of(checkMock));
-    when(AccessibilityHierarchyAndroid.newBuilder(accessibilityNodeInfoMock, contextMock)).thenReturn(builderMock);
+    when(AccessibilityCheckPreset.getAccessibilityHierarchyChecksForPreset(
+            AccessibilityCheckPreset.LATEST))
+        .thenReturn(ImmutableSet.of(checkMock));
+    when(AccessibilityHierarchyAndroid.newBuilder(accessibilityNodeInfoMock, contextMock))
+        .thenReturn(builderMock);
     when(builderMock.build()).thenReturn(hierarchyMock);
-    when(checkMock.runCheckOnHierarchy(hierarchyMock, null, parametersStub)).thenReturn(resultsStub);
-    when(AccessibilityCheckResultUtils.getResultsForTypes(eq(resultsStub), anySet())).thenReturn(filteredResultsStub);
+    when(checkMock.runCheckOnHierarchy(hierarchyMock, null, parametersStub))
+        .thenReturn(resultsStub);
+    when(AccessibilityCheckResultUtils.getResultsForTypes(eq(resultsStub), anySet()))
+        .thenReturn(filteredResultsStub);
 
     Assert.assertEquals(
         testSubject.scanWithATFA(accessibilityNodeInfoMock, screenshotStub), filteredResultsStub);
-
   }
 }

--- a/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/ATFAScannerTest.java
+++ b/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/ATFAScannerTest.java
@@ -4,7 +4,6 @@
 package com.microsoft.accessibilityinsightsforandroidservice;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
@@ -14,7 +13,6 @@ import android.graphics.Bitmap;
 import android.view.accessibility.AccessibilityNodeInfo;
 
 import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckPreset;
-import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResult;
 import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils;
 import com.google.android.apps.common.testing.accessibility.framework.AccessibilityHierarchyCheck;
 import com.google.android.apps.common.testing.accessibility.framework.AccessibilityHierarchyCheckResult;
@@ -32,6 +30,7 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.util.Collections;
 import java.util.List;
 
 @RunWith(PowerMockRunner.class)
@@ -41,22 +40,25 @@ public class ATFAScannerTest {
   @Mock Bitmap bitmapMock;
   @Mock AccessibilityNodeInfo accessibilityNodeInfoMock;
   @Mock Context contextMock;
-  @Mock Parameters parametersMock;
   @Mock AccessibilityHierarchyCheck checkMock;
   @Mock AccessibilityHierarchyAndroid hierarchyMock;
   @Mock AccessibilityHierarchyAndroid.BuilderAndroid builderMock;
-  @Mock List<AccessibilityHierarchyCheckResult> resultsMock;
-  @Mock List<AccessibilityCheckResult> filteredResultsMock;
 
   ATFAScanner testSubject;
-  BitmapImage screenshotMock;
+  Parameters parametersStub;
+  BitmapImage screenshotStub;
+  List<AccessibilityHierarchyCheckResult> resultsStub;
+  List<AccessibilityHierarchyCheckResult> filteredResultsStub;
 
   @Before
   public void prepare() {
     PowerMockito.mockStatic(AccessibilityCheckPreset.class);
     PowerMockito.mockStatic(AccessibilityHierarchyAndroid.class);
     PowerMockito.mockStatic(AccessibilityCheckResultUtils.class);
-    screenshotMock = new BitmapImage(bitmapMock);
+    screenshotStub = new BitmapImage(bitmapMock);
+    parametersStub = new Parameters();
+    resultsStub = Collections.emptyList();
+    filteredResultsStub = Collections.emptyList();
     testSubject = new ATFAScanner(contextMock);
   }
 
@@ -65,11 +67,11 @@ public class ATFAScannerTest {
     when(AccessibilityCheckPreset.getAccessibilityHierarchyChecksForPreset(AccessibilityCheckPreset.LATEST)).thenReturn(ImmutableSet.of(checkMock));
     when(AccessibilityHierarchyAndroid.newBuilder(accessibilityNodeInfoMock, contextMock)).thenReturn(builderMock);
     when(builderMock.build()).thenReturn(hierarchyMock);
-    when(checkMock.runCheckOnHierarchy(hierarchyMock, null, parametersMock)).thenReturn(resultsMock);
-    when(AccessibilityCheckResultUtils.getResultsForTypes(eq(resultsMock), anySet())).thenReturn(filteredResultsMock);
+    when(checkMock.runCheckOnHierarchy(hierarchyMock, null, parametersStub)).thenReturn(resultsStub);
+    when(AccessibilityCheckResultUtils.getResultsForTypes(eq(resultsStub), anySet())).thenReturn(filteredResultsStub);
 
     Assert.assertEquals(
-        testSubject.scanWithATFA(accessibilityNodeInfoMock, screenshotMock), resultsMock);
+        testSubject.scanWithATFA(accessibilityNodeInfoMock, screenshotStub), filteredResultsStub);
 
   }
 }

--- a/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/ATFAScannerTest.java
+++ b/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/ATFAScannerTest.java
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package com.microsoft.accessibilityinsightsforandroidservice;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.view.accessibility.AccessibilityNodeInfo;
+
+import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckPreset;
+import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResult;
+import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils;
+import com.google.android.apps.common.testing.accessibility.framework.AccessibilityHierarchyCheck;
+import com.google.android.apps.common.testing.accessibility.framework.AccessibilityHierarchyCheckResult;
+import com.google.android.apps.common.testing.accessibility.framework.Parameters;
+import com.google.android.apps.common.testing.accessibility.framework.uielement.AccessibilityHierarchyAndroid;
+import com.google.android.apps.common.testing.accessibility.framework.utils.contrast.BitmapImage;
+import com.google.common.collect.ImmutableSet;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.List;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({AccessibilityCheckPreset.class, AccessibilityHierarchyAndroid.class, AccessibilityCheckResultUtils.class})
+public class ATFAScannerTest {
+
+  @Mock Bitmap bitmapMock;
+  @Mock AccessibilityNodeInfo accessibilityNodeInfoMock;
+  @Mock Context contextMock;
+  @Mock Parameters parametersMock;
+  @Mock AccessibilityHierarchyCheck checkMock;
+  @Mock AccessibilityHierarchyAndroid hierarchyMock;
+  @Mock AccessibilityHierarchyAndroid.BuilderAndroid builderMock;
+  @Mock List<AccessibilityHierarchyCheckResult> resultsMock;
+  @Mock List<AccessibilityCheckResult> filteredResultsMock;
+
+  ATFAScanner testSubject;
+  BitmapImage screenshotMock;
+
+  @Before
+  public void prepare() {
+    PowerMockito.mockStatic(AccessibilityCheckPreset.class);
+    PowerMockito.mockStatic(AccessibilityHierarchyAndroid.class);
+    PowerMockito.mockStatic(AccessibilityCheckResultUtils.class);
+    screenshotMock = new BitmapImage(bitmapMock);
+    testSubject = new ATFAScanner(contextMock);
+  }
+
+  @Test
+  public void scanWithATFAReturnsCorrectResult() throws ViewChangedException {
+    when(AccessibilityCheckPreset.getAccessibilityHierarchyChecksForPreset(AccessibilityCheckPreset.LATEST)).thenReturn(ImmutableSet.of(checkMock));
+    when(AccessibilityHierarchyAndroid.newBuilder(accessibilityNodeInfoMock, contextMock)).thenReturn(builderMock);
+    when(builderMock.build()).thenReturn(hierarchyMock);
+    when(checkMock.runCheckOnHierarchy(hierarchyMock, null, parametersMock)).thenReturn(resultsMock);
+    when(AccessibilityCheckResultUtils.getResultsForTypes(eq(resultsMock), anySet())).thenReturn(filteredResultsMock);
+
+    Assert.assertEquals(
+        testSubject.scanWithATFA(accessibilityNodeInfoMock, screenshotMock), resultsMock);
+
+  }
+}


### PR DESCRIPTION
#### Details

<!-- Usually a sentence or two describing what the PR changes -->
This PR creates the ATFAScanner, which uses the [Accessibility Test Framework for Android](https://github.com/google/Accessibility-Test-Framework-for-Android), and the ATFAScannerFactory. Like the existing AxeScanner, the ATFAScanner runs the rules (ATFA instead of axe, in this case) on a given root node and then returns the results. 

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->
This is a part of the feature to add ATFA to AI for Android Service.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
Created an instance of ATFAScanner in AccessibilityInsightsForAndroidService.java, but adding it to the ResponseThreadFactory and RequestHandlerFactory will be done in a future PR, most likely when updating the API.

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->
It also filters the results to return only those with type ERROR, INFO, WARNING, RESOLVED, and NOT_RUN. This can be changed in the future, if we decide that we want to return other types of results. Currently, the only other available result type is SUPPRESSED, but those types of results are not added in the rules that we are using.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [x] Addresses an existing issue: WI 1847154
- [x] Added/updated relevant unit test(s)
- [x] Ran `./gradlew fastpass` from `AccessibilityInsightsForAndroidService`
- [x] PR title _AND_ final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`).
