### PR TITLE
feat(google-rules-mvp-service): Run, serialize, and return ATFA results

### DIFF
--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/AccessibilityInsightsForAndroidService.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/AccessibilityInsightsForAndroidService.java
@@ -126,7 +126,7 @@ public class AccessibilityInsightsForAndroidService extends AccessibilityService
 
     ResponseThreadFactory responseThreadFactory =
         new ResponseThreadFactory(
-            screenshotController, eventHelper, axeScanner, deviceConfigFactory, focusVisualizationStateManager);
+            screenshotController, eventHelper, axeScanner, atfaScanner, deviceConfigFactory, focusVisualizationStateManager);
     ServerThread = new ServerThread(new ServerSocketFactory(), responseThreadFactory);
     ServerThread.start();
   }

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/RequestHandlerFactory.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/RequestHandlerFactory.java
@@ -9,6 +9,7 @@ public class RequestHandlerFactory {
 
   private final ScreenshotController screenshotController;
   private final AxeScanner axeScanner;
+  private final ATFAScanner atfaScanner;
   private final RootNodeFinder rootNodeFinder;
   private final EventHelper eventHelper;
   private final DeviceConfigFactory deviceConfigFactory;
@@ -21,12 +22,14 @@ public class RequestHandlerFactory {
       RootNodeFinder rootNodeFinder,
       EventHelper eventHelper,
       AxeScanner axeScanner,
+      ATFAScanner atfaScanner,
       DeviceConfigFactory deviceConfigFactory,
       RequestHandlerImplFactory requestHandlerImplFactory,
       FocusVisualizationStateManager focusVisualizationStateManager,
       ResultSerializer resultSerializer) {
     this.screenshotController = screenshotController;
     this.axeScanner = axeScanner;
+    this.atfaScanner = atfaScanner;
     this.rootNodeFinder = rootNodeFinder;
     this.eventHelper = eventHelper;
     this.deviceConfigFactory = deviceConfigFactory;
@@ -46,6 +49,7 @@ public class RequestHandlerFactory {
                 rootNodeFinder,
                 eventHelper,
                 axeScanner,
+                atfaScanner,
                 screenshotController,
                 resultSerializer);
         return requestHandlerImplFactory.createRequestHandler(

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/RequestHandlerFactory.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/RequestHandlerFactory.java
@@ -15,7 +15,7 @@ public class RequestHandlerFactory {
   private final DeviceConfigFactory deviceConfigFactory;
   private final RequestHandlerImplFactory requestHandlerImplFactory;
   private final FocusVisualizationStateManager focusVisualizationStateManager;
-  private final ResultSerializer resultSerializer;
+  private final ResultsContainerSerializer resultsContainerSerializer;
 
   public RequestHandlerFactory(
       ScreenshotController screenshotController,
@@ -26,7 +26,7 @@ public class RequestHandlerFactory {
       DeviceConfigFactory deviceConfigFactory,
       RequestHandlerImplFactory requestHandlerImplFactory,
       FocusVisualizationStateManager focusVisualizationStateManager,
-      ResultSerializer resultSerializer) {
+      ResultsContainerSerializer resultsContainerSerializer) {
     this.screenshotController = screenshotController;
     this.axeScanner = axeScanner;
     this.atfaScanner = atfaScanner;
@@ -35,7 +35,7 @@ public class RequestHandlerFactory {
     this.deviceConfigFactory = deviceConfigFactory;
     this.requestHandlerImplFactory = requestHandlerImplFactory;
     this.focusVisualizationStateManager = focusVisualizationStateManager;
-    this.resultSerializer = resultSerializer;
+    this.resultsContainerSerializer = resultsContainerSerializer;
   }
 
   public RequestHandler createHandlerForRequest(
@@ -51,7 +51,7 @@ public class RequestHandlerFactory {
                 axeScanner,
                 atfaScanner,
                 screenshotController,
-                resultSerializer);
+                resultsContainerSerializer);
         return requestHandlerImplFactory.createRequestHandler(
             socketHolder,
             resultRequestFulfiller,

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ResponseThreadFactory.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ResponseThreadFactory.java
@@ -3,6 +3,7 @@
 
 package com.microsoft.accessibilityinsightsforandroidservice;
 
+import com.google.gson.GsonBuilder;
 import java.net.Socket;
 
 public class ResponseThreadFactory {
@@ -14,6 +15,7 @@ public class ResponseThreadFactory {
       ScreenshotController screenshotController,
       EventHelper eventHelper,
       AxeScanner axeScanner,
+      ATFAScanner atfaScanner,
       DeviceConfigFactory deviceConfigFactory,
       FocusVisualizationStateManager focusVisualizationStateManager) {
     responseWriterFactory = new ResponseWriterFactory();
@@ -24,10 +26,11 @@ public class ResponseThreadFactory {
             new RootNodeFinder(),
             eventHelper,
             axeScanner,
+            atfaScanner,
             deviceConfigFactory,
             new RequestHandlerImplFactory(),
             focusVisualizationStateManager,
-            new ResultSerializer());
+            new ResultSerializer(new ATFAResultsSerializer(new GsonBuilder()), new GsonBuilder()));
   }
 
   public ResponseThread createResponseThread(Socket socket) {

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ResponseThreadFactory.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ResponseThreadFactory.java
@@ -30,7 +30,8 @@ public class ResponseThreadFactory {
             deviceConfigFactory,
             new RequestHandlerImplFactory(),
             focusVisualizationStateManager,
-            new ResultSerializer(new ATFAResultsSerializer(new GsonBuilder()), new GsonBuilder()));
+            new ResultsContainerSerializer(
+                new ATFAResultsSerializer(new GsonBuilder()), new GsonBuilder()));
   }
 
   public ResponseThread createResponseThread(Socket socket) {

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ResultRequestFulfiller.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ResultRequestFulfiller.java
@@ -6,12 +6,16 @@ package com.microsoft.accessibilityinsightsforandroidservice;
 import android.graphics.Bitmap;
 import android.view.accessibility.AccessibilityNodeInfo;
 import com.deque.axe.android.AxeResult;
+import com.google.android.apps.common.testing.accessibility.framework.AccessibilityHierarchyCheckResult;
+import com.google.android.apps.common.testing.accessibility.framework.utils.contrast.BitmapImage;
+import java.util.List;
 
 public class ResultRequestFulfiller implements RequestFulfiller {
   private final RootNodeFinder rootNodeFinder;
   private final EventHelper eventHelper;
   private final ResponseWriter responseWriter;
   private final AxeScanner axeScanner;
+  private final ATFAScanner atfaScanner;
   private final ScreenshotController screenshotController;
   private final ResultSerializer resultSerializer;
 
@@ -20,12 +24,14 @@ public class ResultRequestFulfiller implements RequestFulfiller {
       RootNodeFinder rootNodeFinder,
       EventHelper eventHelper,
       AxeScanner axeScanner,
+      ATFAScanner atfaScanner,
       ScreenshotController screenshotController,
       ResultSerializer resultSerializer) {
     this.responseWriter = responseWriter;
     this.rootNodeFinder = rootNodeFinder;
     this.eventHelper = eventHelper;
     this.axeScanner = axeScanner;
+    this.atfaScanner = atfaScanner;
     this.screenshotController = screenshotController;
     this.resultSerializer = resultSerializer;
   }
@@ -68,7 +74,9 @@ public class ResultRequestFulfiller implements RequestFulfiller {
       throw new ScanException("Scanner returned no data");
     }
 
-    resultSerializer.addAxeResult(result);
-    return resultSerializer.generateResultJson();
+    List<AccessibilityHierarchyCheckResult> results =
+        atfaScanner.scanWithATFA(rootNode, new BitmapImage(screenshot));
+
+    return resultSerializer.createResultsJson(result, results);
   }
 }

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ResultRequestFulfiller.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ResultRequestFulfiller.java
@@ -17,7 +17,7 @@ public class ResultRequestFulfiller implements RequestFulfiller {
   private final AxeScanner axeScanner;
   private final ATFAScanner atfaScanner;
   private final ScreenshotController screenshotController;
-  private final ResultSerializer resultSerializer;
+  private final ResultsContainerSerializer resultsContainerSerializer;
 
   public ResultRequestFulfiller(
       ResponseWriter responseWriter,
@@ -26,14 +26,14 @@ public class ResultRequestFulfiller implements RequestFulfiller {
       AxeScanner axeScanner,
       ATFAScanner atfaScanner,
       ScreenshotController screenshotController,
-      ResultSerializer resultSerializer) {
+      ResultsContainerSerializer resultsContainerSerializer) {
     this.responseWriter = responseWriter;
     this.rootNodeFinder = rootNodeFinder;
     this.eventHelper = eventHelper;
     this.axeScanner = axeScanner;
     this.atfaScanner = atfaScanner;
     this.screenshotController = screenshotController;
-    this.resultSerializer = resultSerializer;
+    this.resultsContainerSerializer = resultsContainerSerializer;
   }
 
   public void fulfillRequest(RunnableFunction onRequestFulfilled) {
@@ -69,14 +69,14 @@ public class ResultRequestFulfiller implements RequestFulfiller {
     if (rootNode == null) {
       throw new ScanException("Unable to locate root node to scan");
     }
-    AxeResult result = axeScanner.scanWithAxe(rootNode, screenshot);
-    if (result == null) {
+    AxeResult axeResult = axeScanner.scanWithAxe(rootNode, screenshot);
+    if (axeResult == null) {
       throw new ScanException("Scanner returned no data");
     }
 
-    List<AccessibilityHierarchyCheckResult> results =
+    List<AccessibilityHierarchyCheckResult> atfaResults =
         atfaScanner.scanWithATFA(rootNode, new BitmapImage(screenshot));
 
-    return resultSerializer.createResultsJson(result, results);
+    return resultsContainerSerializer.createResultsJson(axeResult, atfaResults);
   }
 }

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ResultsContainer.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ResultsContainer.java
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package com.microsoft.accessibilityinsightsforandroidservice;
+
+import com.deque.axe.android.AxeResult;
+import com.google.android.apps.common.testing.accessibility.framework.AccessibilityHierarchyCheckResult;
+import java.util.List;
+
+public class ResultsContainer {
+  public List<AccessibilityHierarchyCheckResult> ATFAResults;
+  public AxeResult AxeResult;
+}

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ResultsContainerSerializer.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ResultsContainerSerializer.java
@@ -13,7 +13,7 @@ import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.util.List;
 
-public class ResultSerializer {
+public class ResultsContainerSerializer {
   private final ATFAResultsSerializer atfaResultsSerializer;
   private final Gson gson;
   private final TypeAdapter<ResultsContainer> resultsContainerTypeAdapter =
@@ -33,7 +33,8 @@ public class ResultSerializer {
         }
       };
 
-  public ResultSerializer(ATFAResultsSerializer atfaResultsSerializer, GsonBuilder gsonBuilder) {
+  public ResultsContainerSerializer(
+      ATFAResultsSerializer atfaResultsSerializer, GsonBuilder gsonBuilder) {
     this.atfaResultsSerializer = atfaResultsSerializer;
     this.gson =
         gsonBuilder

--- a/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/RequestHandlerFactoryTest.java
+++ b/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/RequestHandlerFactoryTest.java
@@ -28,7 +28,7 @@ public class RequestHandlerFactoryTest {
   @Mock ResponseWriter responseWriter;
   @Mock RequestHandlerImplFactory requestHandlerImplFactory;
   @Mock FocusVisualizationStateManager focusVisualizationStateManager;
-  @Mock ResultSerializer resultSerializer;
+  @Mock ResultsContainerSerializer resultsContainerSerializer;
 
   RequestHandlerFactory testSubject;
 
@@ -44,7 +44,7 @@ public class RequestHandlerFactoryTest {
             deviceConfigFactory,
             requestHandlerImplFactory,
             focusVisualizationStateManager,
-            resultSerializer);
+            resultsContainerSerializer);
   }
 
   @Test

--- a/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/RequestHandlerFactoryTest.java
+++ b/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/RequestHandlerFactoryTest.java
@@ -20,6 +20,7 @@ public class RequestHandlerFactoryTest {
 
   @Mock ScreenshotController screenshotController;
   @Mock AxeScanner axeScanner;
+  @Mock ATFAScanner atfaScanner;
   @Mock RootNodeFinder rootNodeFinder;
   @Mock EventHelper eventHelper;
   @Mock DeviceConfigFactory deviceConfigFactory;
@@ -39,6 +40,7 @@ public class RequestHandlerFactoryTest {
             rootNodeFinder,
             eventHelper,
             axeScanner,
+            atfaScanner,
             deviceConfigFactory,
             requestHandlerImplFactory,
             focusVisualizationStateManager,

--- a/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/ResultRequestFulfillerTest.java
+++ b/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/ResultRequestFulfillerTest.java
@@ -43,7 +43,7 @@ public class ResultRequestFulfillerTest {
   @Mock AccessibilityNodeInfo rootNode;
   @Mock AxeResult axeResultMock;
   @Mock RunnableFunction onRequestFulfilledMock;
-  @Mock ResultSerializer resultSerializer;
+  @Mock ResultsContainerSerializer resultsContainerSerializer;
 
   final List<AccessibilityHierarchyCheckResult> atfaResults = Collections.emptyList();
   final String scanResultJson = "axe scan result";
@@ -67,7 +67,7 @@ public class ResultRequestFulfillerTest {
             axeScanner,
             atfaScanner,
             screenshotController,
-            resultSerializer);
+            resultsContainerSerializer);
   }
 
   @Test
@@ -184,7 +184,8 @@ public class ResultRequestFulfillerTest {
       Assert.fail(e.getMessage());
     }
     when(atfaScanner.scanWithATFA(eq(sourceNode), any())).thenReturn(atfaResults);
-    when(resultSerializer.createResultsJson(axeResultMock, atfaResults)).thenReturn(scanResultJson);
+    when(resultsContainerSerializer.createResultsJson(axeResultMock, atfaResults))
+        .thenReturn(scanResultJson);
   }
 
   private void verifyOnRequestFulfilledCalled() {

--- a/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/ResultSerializerTest.java
+++ b/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/ResultSerializerTest.java
@@ -3,45 +3,100 @@
 
 package com.microsoft.accessibilityinsightsforandroidservice;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.deque.axe.android.AxeResult;
+import com.google.android.apps.common.testing.accessibility.framework.AccessibilityHierarchyCheckResult;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.AdditionalAnswers;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({GsonBuilder.class, Gson.class})
 public class ResultSerializerTest {
 
   @Mock AxeResult axeResultMock;
+  @Mock ATFAResultsSerializer atfaResultsSerializer;
+  @Mock GsonBuilder gsonBuilder;
+  @Mock JsonWriter jsonWriter;
+  @Mock Gson gson;
 
+  final List<AccessibilityHierarchyCheckResult> atfaResults = Collections.emptyList();
+  final ResultsContainer resultsContainer = new ResultsContainer();
+
+  TypeAdapter<ResultsContainer> resultsContainerTypeAdapter;
   ResultSerializer testSubject;
-
-  final String scanResultJson = "axe scan result";
 
   @Before
   public void prepare() {
-    testSubject = new ResultSerializer();
-  }
+    doAnswer(
+            AdditionalAnswers.answer(
+                (Type type, TypeAdapter<ResultsContainer> typeAdapter) -> {
+                  resultsContainerTypeAdapter = typeAdapter;
+                  return gsonBuilder;
+                }))
+        .when(gsonBuilder)
+        .registerTypeAdapter(eq(ResultsContainer.class), any());
 
-  @Test
-  public void resultSerializerExists() {
-    Assert.assertNotNull(testSubject);
+    when(gsonBuilder.create()).thenReturn(gson);
+    resultsContainer.AxeResult = axeResultMock;
+    resultsContainer.ATFAResults = atfaResults;
+    testSubject = new ResultSerializer(atfaResultsSerializer, gsonBuilder);
   }
 
   @Test
   public void generatesExpectedJson() {
-    when(axeResultMock.toJson()).thenReturn(scanResultJson);
+    AtomicReference<ResultsContainer> resultsContainer = new AtomicReference<>();
+    doAnswer(
+            AdditionalAnswers.answer(
+                (ResultsContainer container) -> {
+                  resultsContainer.set(container);
+                  return "Test String";
+                }))
+        .when(gson)
+        .toJson(any(ResultsContainer.class));
 
-    testSubject.addAxeResult(axeResultMock);
-    String generatedJson = testSubject.generateResultJson();
+    testSubject.createResultsJson(axeResultMock, atfaResults);
 
+    Assert.assertEquals(axeResultMock, resultsContainer.get().AxeResult);
+    Assert.assertEquals(atfaResults, resultsContainer.get().ATFAResults);
+  }
+
+  @Test
+  public void typeAdapterSerializes() throws IOException {
+    String axeJson = "axe scan result";
+    String atfaJson = "atfa scan results";
+
+    when(axeResultMock.toJson()).thenReturn(axeJson);
+    when(atfaResultsSerializer.serializeATFAResults(atfaResults)).thenReturn(atfaJson);
+    when(jsonWriter.name("AxeResults")).thenReturn(jsonWriter);
+    when(jsonWriter.name("ATFAResults")).thenReturn(jsonWriter);
+
+    resultsContainerTypeAdapter.write(jsonWriter, resultsContainer);
+
+    verify(jsonWriter, times(1)).beginObject();
+    verify(jsonWriter, times(1)).jsonValue(axeJson);
+    verify(jsonWriter, times(1)).jsonValue(atfaJson);
+    verify(jsonWriter, times(1)).endObject();
     verify(axeResultMock, times(1)).toJson();
-    Assert.assertEquals(generatedJson, scanResultJson);
   }
 }

--- a/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/ResultsContainerSerializerTest.java
+++ b/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/ResultsContainerSerializerTest.java
@@ -32,7 +32,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({GsonBuilder.class, Gson.class})
-public class ResultSerializerTest {
+public class ResultsContainerSerializerTest {
 
   @Mock AxeResult axeResultMock;
   @Mock ATFAResultsSerializer atfaResultsSerializer;
@@ -44,7 +44,7 @@ public class ResultSerializerTest {
   final ResultsContainer resultsContainer = new ResultsContainer();
 
   TypeAdapter<ResultsContainer> resultsContainerTypeAdapter;
-  ResultSerializer testSubject;
+  ResultsContainerSerializer testSubject;
 
   @Before
   public void prepare() {
@@ -60,7 +60,7 @@ public class ResultSerializerTest {
     when(gsonBuilder.create()).thenReturn(gson);
     resultsContainer.AxeResult = axeResultMock;
     resultsContainer.ATFAResults = atfaResults;
-    testSubject = new ResultSerializer(atfaResultsSerializer, gsonBuilder);
+    testSubject = new ResultsContainerSerializer(atfaResultsSerializer, gsonBuilder);
   }
 
   @Test


### PR DESCRIPTION
#### Details
Previous PRs introduced `ATFAScanner`, `ATFAResultSerializer`, and `ResultSerializer` (#104, #108, and #102). This PR puts them together to run, serialize, and return ATFA results. To accomplish this, `ResultsContainer` is introduced and `ResultSerializer` is refactored to serialize it. 

##### Motivation
Now ATFA rules are run and results are returned!

##### Context
A future PR will add ATFARules to the return object, as well. 

Note that these changes will require updates on the AI-Android client receiving end.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] Addresses an existing issue: #0000
- [x] Added/updated relevant unit test(s)
- [x] Ran `./gradlew fastpass` from `AccessibilityInsightsForAndroidService`
- [x] PR title _AND_ final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`).
