### PR TITLE
feat(google-rules-mvp-service): add ATFARulesSerializer to ResultsContainerSerializer

### DIFF
--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ResponseThreadFactory.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ResponseThreadFactory.java
@@ -31,7 +31,9 @@ public class ResponseThreadFactory {
             new RequestHandlerImplFactory(),
             focusVisualizationStateManager,
             new ResultsContainerSerializer(
-                new ATFAResultsSerializer(new GsonBuilder()), new GsonBuilder()));
+                new ATFARulesSerializer(),
+                new ATFAResultsSerializer(new GsonBuilder()),
+                new GsonBuilder()));
   }
 
   public ResponseThread createResponseThread(Socket socket) {

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ResultsContainerSerializer.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ResultsContainerSerializer.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.util.List;
 
 public class ResultsContainerSerializer {
+  private final ATFARulesSerializer atfaRulesSerializer;
   private final ATFAResultsSerializer atfaResultsSerializer;
   private final Gson gson;
   private final TypeAdapter<ResultsContainer> resultsContainerTypeAdapter =
@@ -22,6 +23,7 @@ public class ResultsContainerSerializer {
         public void write(JsonWriter out, ResultsContainer value) throws IOException {
           out.beginObject();
           out.name("AxeResults").jsonValue(value.AxeResult.toJson());
+          out.name("ATFARules").jsonValue(atfaRulesSerializer.serializeATFARules());
           out.name("ATFAResults")
               .jsonValue(atfaResultsSerializer.serializeATFAResults(value.ATFAResults));
           out.endObject();
@@ -40,6 +42,7 @@ public class ResultsContainerSerializer {
         gsonBuilder
             .registerTypeAdapter(ResultsContainer.class, this.resultsContainerTypeAdapter)
             .create();
+    this.atfaRulesSerializer = new ATFARulesSerializer();
   }
 
   public String createResultsJson(

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ResultsContainerSerializer.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ResultsContainerSerializer.java
@@ -36,13 +36,15 @@ public class ResultsContainerSerializer {
       };
 
   public ResultsContainerSerializer(
-      ATFAResultsSerializer atfaResultsSerializer, GsonBuilder gsonBuilder) {
+      ATFARulesSerializer atfaRulesSerializer,
+      ATFAResultsSerializer atfaResultsSerializer,
+      GsonBuilder gsonBuilder) {
+    this.atfaRulesSerializer = atfaRulesSerializer;
     this.atfaResultsSerializer = atfaResultsSerializer;
     this.gson =
         gsonBuilder
             .registerTypeAdapter(ResultsContainer.class, this.resultsContainerTypeAdapter)
             .create();
-    this.atfaRulesSerializer = new ATFARulesSerializer();
   }
 
   public String createResultsJson(

--- a/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/ResultsContainerSerializerTest.java
+++ b/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/ResultsContainerSerializerTest.java
@@ -35,6 +35,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 public class ResultsContainerSerializerTest {
 
   @Mock AxeResult axeResultMock;
+  @Mock ATFARulesSerializer atfaRulesSerializer;
   @Mock ATFAResultsSerializer atfaResultsSerializer;
   @Mock GsonBuilder gsonBuilder;
   @Mock JsonWriter jsonWriter;
@@ -60,7 +61,8 @@ public class ResultsContainerSerializerTest {
     when(gsonBuilder.create()).thenReturn(gson);
     resultsContainer.AxeResult = axeResultMock;
     resultsContainer.ATFAResults = atfaResults;
-    testSubject = new ResultsContainerSerializer(atfaResultsSerializer, gsonBuilder);
+    testSubject =
+        new ResultsContainerSerializer(atfaRulesSerializer, atfaResultsSerializer, gsonBuilder);
   }
 
   @Test
@@ -84,17 +86,21 @@ public class ResultsContainerSerializerTest {
   @Test
   public void typeAdapterSerializes() throws IOException {
     String axeJson = "axe scan result";
+    String atfaRulesJson = "atfa rules";
     String atfaJson = "atfa scan results";
 
     when(axeResultMock.toJson()).thenReturn(axeJson);
+    when(atfaRulesSerializer.serializeATFARules()).thenReturn(atfaRulesJson);
     when(atfaResultsSerializer.serializeATFAResults(atfaResults)).thenReturn(atfaJson);
     when(jsonWriter.name("AxeResults")).thenReturn(jsonWriter);
+    when(jsonWriter.name("ATFARules")).thenReturn(jsonWriter);
     when(jsonWriter.name("ATFAResults")).thenReturn(jsonWriter);
 
     resultsContainerTypeAdapter.write(jsonWriter, resultsContainer);
 
     verify(jsonWriter, times(1)).beginObject();
     verify(jsonWriter, times(1)).jsonValue(axeJson);
+    verify(jsonWriter, times(1)).jsonValue(atfaRulesJson);
     verify(jsonWriter, times(1)).jsonValue(atfaJson);
     verify(jsonWriter, times(1)).endObject();
     verify(axeResultMock, times(1)).toJson();


### PR DESCRIPTION
#### Details

<!-- Usually a sentence or two describing what the PR changes -->
This adds the ATFARulesSerializer from #111 to the ResultsContainerSerializer from #102 and #110.

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->
Part of feature 1833283

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
This is the last part needed to get the ResultsContainerSerializer to return a json with all the necessary data. 
<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->
The returned json is formatted like the following:
```
{ 
  AxeResults: {...},
  ATFARules: [...},
  ATFAResults: [...]
}
```

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [x] Addresses part of an existing feature: 1833283
- [x] Added/updated relevant unit test(s)
- [x] Ran `./gradlew fastpass` from `AccessibilityInsightsForAndroidService`
- [x] PR title _AND_ final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`).
