### PR TITLE
fix: Exclude Pattern from ATFA rules serialization

### DIFF
--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ATFARulesSerializer.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ATFARulesSerializer.java
@@ -22,9 +22,12 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+import java.util.regex.Pattern;
 
 public class ATFARulesSerializer {
   private static final List<String> FieldsToSkip = Arrays.asList("ANDROID_A11Y_HELP_URL");
+
+  private static final List<Class> ClassesToSkip = Arrays.asList(Pattern.class);
 
   private static final ExclusionStrategy ATFARuleExclusionStrategy =
       new ExclusionStrategy() {
@@ -35,7 +38,7 @@ public class ATFARulesSerializer {
 
         @Override
         public boolean shouldSkipClass(Class<?> clazz) {
-          return false;
+          return ClassesToSkip.contains(clazz);
         }
       };
 

--- a/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/ATFARulesSerializerTest.java
+++ b/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/ATFARulesSerializerTest.java
@@ -18,6 +18,7 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.JsonParser;
 import java.util.List;
 import java.util.Locale;
+import java.util.regex.Pattern;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -34,6 +35,7 @@ public class ATFARulesSerializerTest {
   class TestCheckClass extends AccessibilityHierarchyCheck {
     private static final String ANDROID_A11Y_HELP_URL = "excluded from serialized rule";
     private static final String TEST_RESULT_ID = "test result id included in serialized rule";
+    private final Pattern TEST_PATTERN_TO_BE_SKIPPED = Pattern.compile("");
 
     @Override
     protected String getHelpTopic() {


### PR DESCRIPTION
#### Details
This PR causes the `Pattern` class to be excluded from ATFA rules serialization.

##### Motivation
On Android versions prior to Android 9, the `Pattern` class cannot be serialized by the default Gson serializer. Thus, the [`Pattern` in `LinkPurposeUnclearCheck`](https://github.com/google/Accessibility-Test-Framework-for-Android/blob/master/src/main/java/com/google/android/apps/common/testing/accessibility/framework/checks/LinkPurposeUnclearCheck.java#L64) causes our serialization to fail on older Android versions.

##### Context
Another option would be to implement a custom serializer for the `Pattern` class. We don't get anything interesting from `Pattern`, so we don't need to do that.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] Addresses an existing issue: #0000
- [x] Added/updated relevant unit test(s)
- [x] Ran `./gradlew fastpass` from `AccessibilityInsightsForAndroidService`
- [x] PR title _AND_ final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`).
