### PR TITLE
chore: Support v1 and v2 versions of results API

### DIFF
--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/RequestHandlerFactory.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/RequestHandlerFactory.java
@@ -15,6 +15,7 @@ public class RequestHandlerFactory {
   private final DeviceConfigFactory deviceConfigFactory;
   private final RequestHandlerImplFactory requestHandlerImplFactory;
   private final FocusVisualizationStateManager focusVisualizationStateManager;
+  private final ResultV1Serializer resultV1Serializer;
   private final ResultsContainerSerializer resultsContainerSerializer;
 
   public RequestHandlerFactory(
@@ -26,6 +27,7 @@ public class RequestHandlerFactory {
       DeviceConfigFactory deviceConfigFactory,
       RequestHandlerImplFactory requestHandlerImplFactory,
       FocusVisualizationStateManager focusVisualizationStateManager,
+      ResultV1Serializer resultV1Serializer,
       ResultsContainerSerializer resultsContainerSerializer) {
     this.screenshotController = screenshotController;
     this.axeScanner = axeScanner;
@@ -35,6 +37,7 @@ public class RequestHandlerFactory {
     this.deviceConfigFactory = deviceConfigFactory;
     this.requestHandlerImplFactory = requestHandlerImplFactory;
     this.focusVisualizationStateManager = focusVisualizationStateManager;
+    this.resultV1Serializer = resultV1Serializer;
     this.resultsContainerSerializer = resultsContainerSerializer;
   }
 
@@ -42,7 +45,7 @@ public class RequestHandlerFactory {
       Socket socket, String requestString, ResponseWriter responseWriter) {
     SocketHolder socketHolder = new SocketHolder(socket);
     if (requestString != null) {
-      if (requestString.startsWith("GET /AccessibilityInsights/result ")) {
+      if (requestString.startsWith("GET /AccessibilityInsights/result_v2 ")) {
         ResultRequestFulfiller resultRequestFulfiller =
             new ResultRequestFulfiller(
                 responseWriter,
@@ -57,6 +60,21 @@ public class RequestHandlerFactory {
             resultRequestFulfiller,
             "processResultRequest",
             "*** About to process scan request");
+      }
+      if (requestString.startsWith("GET /AccessibilityInsights/result ")) {
+        ResultV1RequestFulfiller resultRequestFulfiller =
+                new ResultV1RequestFulfiller(
+                        responseWriter,
+                        rootNodeFinder,
+                        eventHelper,
+                        axeScanner,
+                        screenshotController,
+                        resultV1Serializer);
+        return requestHandlerImplFactory.createRequestHandler(
+                socketHolder,
+                resultRequestFulfiller,
+                "processResultRequest",
+                "*** About to process scan request");
       }
       if (requestString.startsWith("GET /AccessibilityInsights/config ")) {
         ConfigRequestFulfiller configRequestFulfiller =

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/RequestHandlerFactory.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/RequestHandlerFactory.java
@@ -63,18 +63,18 @@ public class RequestHandlerFactory {
       }
       if (requestString.startsWith("GET /AccessibilityInsights/result ")) {
         ResultV1RequestFulfiller resultRequestFulfiller =
-                new ResultV1RequestFulfiller(
-                        responseWriter,
-                        rootNodeFinder,
-                        eventHelper,
-                        axeScanner,
-                        screenshotController,
-                        resultV1Serializer);
+            new ResultV1RequestFulfiller(
+                responseWriter,
+                rootNodeFinder,
+                eventHelper,
+                axeScanner,
+                screenshotController,
+                resultV1Serializer);
         return requestHandlerImplFactory.createRequestHandler(
-                socketHolder,
-                resultRequestFulfiller,
-                "processResultRequest",
-                "*** About to process scan request");
+            socketHolder,
+            resultRequestFulfiller,
+            "processResultRequest",
+            "*** About to process scan request");
       }
       if (requestString.startsWith("GET /AccessibilityInsights/config ")) {
         ConfigRequestFulfiller configRequestFulfiller =

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ResponseThreadFactory.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ResponseThreadFactory.java
@@ -30,6 +30,7 @@ public class ResponseThreadFactory {
             deviceConfigFactory,
             new RequestHandlerImplFactory(),
             focusVisualizationStateManager,
+            new ResultV1Serializer(),
             new ResultsContainerSerializer(
                 new ATFARulesSerializer(),
                 new ATFAResultsSerializer(new GsonBuilder()),

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ResultV1RequestFulfiller.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ResultV1RequestFulfiller.java
@@ -1,0 +1,74 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package com.microsoft.accessibilityinsightsforandroidservice;
+
+import android.graphics.Bitmap;
+import android.view.accessibility.AccessibilityNodeInfo;
+import com.deque.axe.android.AxeResult;
+
+public class ResultV1RequestFulfiller implements RequestFulfiller {
+    private final RootNodeFinder rootNodeFinder;
+    private final EventHelper eventHelper;
+    private final ResponseWriter responseWriter;
+    private final AxeScanner axeScanner;
+    private final ScreenshotController screenshotController;
+    private final ResultV1Serializer resultSerializer;
+
+    public ResultV1RequestFulfiller(
+            ResponseWriter responseWriter,
+            RootNodeFinder rootNodeFinder,
+            EventHelper eventHelper,
+            AxeScanner axeScanner,
+            ScreenshotController screenshotController,
+            ResultV1Serializer resultSerializer) {
+        this.responseWriter = responseWriter;
+        this.rootNodeFinder = rootNodeFinder;
+        this.eventHelper = eventHelper;
+        this.axeScanner = axeScanner;
+        this.screenshotController = screenshotController;
+        this.resultSerializer = resultSerializer;
+    }
+
+    public void fulfillRequest(RunnableFunction onRequestFulfilled) {
+        screenshotController.getScreenshotWithMediaProjection(
+                screenshot -> {
+                    try {
+                        AccessibilityNodeInfo source = eventHelper.claimLastSource();
+                        AccessibilityNodeInfo rootNode = rootNodeFinder.getRootNodeFromSource(source);
+
+                        String content = getScanContent(rootNode, screenshot);
+                        responseWriter.writeSuccessfulResponse(content);
+
+                        if (rootNode != null && rootNode != source) {
+                            rootNode.recycle();
+                        }
+                        if (source != null && !eventHelper.restoreLastSource(source)) {
+                            source.recycle();
+                        }
+                    } catch (Exception e) {
+                        responseWriter.writeErrorResponse(e);
+                    }
+                    onRequestFulfilled.run();
+                });
+    }
+
+    @Override
+    public boolean isBlockingRequest() {
+        return true;
+    }
+
+    private String getScanContent(AccessibilityNodeInfo rootNode, Bitmap screenshot)
+            throws ScanException, ViewChangedException {
+        if (rootNode == null) {
+            throw new ScanException("Unable to locate root node to scan");
+        }
+        AxeResult axeResult = axeScanner.scanWithAxe(rootNode, screenshot);
+        if (axeResult == null) {
+            throw new ScanException("Scanner returned no data");
+        }
+
+        resultSerializer.addAxeResult(axeResult);
+        return resultSerializer.generateResultJson();
+    }
+}

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ResultV1RequestFulfiller.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ResultV1RequestFulfiller.java
@@ -8,67 +8,67 @@ import android.view.accessibility.AccessibilityNodeInfo;
 import com.deque.axe.android.AxeResult;
 
 public class ResultV1RequestFulfiller implements RequestFulfiller {
-    private final RootNodeFinder rootNodeFinder;
-    private final EventHelper eventHelper;
-    private final ResponseWriter responseWriter;
-    private final AxeScanner axeScanner;
-    private final ScreenshotController screenshotController;
-    private final ResultV1Serializer resultSerializer;
+  private final RootNodeFinder rootNodeFinder;
+  private final EventHelper eventHelper;
+  private final ResponseWriter responseWriter;
+  private final AxeScanner axeScanner;
+  private final ScreenshotController screenshotController;
+  private final ResultV1Serializer resultSerializer;
 
-    public ResultV1RequestFulfiller(
-            ResponseWriter responseWriter,
-            RootNodeFinder rootNodeFinder,
-            EventHelper eventHelper,
-            AxeScanner axeScanner,
-            ScreenshotController screenshotController,
-            ResultV1Serializer resultSerializer) {
-        this.responseWriter = responseWriter;
-        this.rootNodeFinder = rootNodeFinder;
-        this.eventHelper = eventHelper;
-        this.axeScanner = axeScanner;
-        this.screenshotController = screenshotController;
-        this.resultSerializer = resultSerializer;
+  public ResultV1RequestFulfiller(
+      ResponseWriter responseWriter,
+      RootNodeFinder rootNodeFinder,
+      EventHelper eventHelper,
+      AxeScanner axeScanner,
+      ScreenshotController screenshotController,
+      ResultV1Serializer resultSerializer) {
+    this.responseWriter = responseWriter;
+    this.rootNodeFinder = rootNodeFinder;
+    this.eventHelper = eventHelper;
+    this.axeScanner = axeScanner;
+    this.screenshotController = screenshotController;
+    this.resultSerializer = resultSerializer;
+  }
+
+  public void fulfillRequest(RunnableFunction onRequestFulfilled) {
+    screenshotController.getScreenshotWithMediaProjection(
+        screenshot -> {
+          try {
+            AccessibilityNodeInfo source = eventHelper.claimLastSource();
+            AccessibilityNodeInfo rootNode = rootNodeFinder.getRootNodeFromSource(source);
+
+            String content = getScanContent(rootNode, screenshot);
+            responseWriter.writeSuccessfulResponse(content);
+
+            if (rootNode != null && rootNode != source) {
+              rootNode.recycle();
+            }
+            if (source != null && !eventHelper.restoreLastSource(source)) {
+              source.recycle();
+            }
+          } catch (Exception e) {
+            responseWriter.writeErrorResponse(e);
+          }
+          onRequestFulfilled.run();
+        });
+  }
+
+  @Override
+  public boolean isBlockingRequest() {
+    return true;
+  }
+
+  private String getScanContent(AccessibilityNodeInfo rootNode, Bitmap screenshot)
+      throws ScanException, ViewChangedException {
+    if (rootNode == null) {
+      throw new ScanException("Unable to locate root node to scan");
+    }
+    AxeResult axeResult = axeScanner.scanWithAxe(rootNode, screenshot);
+    if (axeResult == null) {
+      throw new ScanException("Scanner returned no data");
     }
 
-    public void fulfillRequest(RunnableFunction onRequestFulfilled) {
-        screenshotController.getScreenshotWithMediaProjection(
-                screenshot -> {
-                    try {
-                        AccessibilityNodeInfo source = eventHelper.claimLastSource();
-                        AccessibilityNodeInfo rootNode = rootNodeFinder.getRootNodeFromSource(source);
-
-                        String content = getScanContent(rootNode, screenshot);
-                        responseWriter.writeSuccessfulResponse(content);
-
-                        if (rootNode != null && rootNode != source) {
-                            rootNode.recycle();
-                        }
-                        if (source != null && !eventHelper.restoreLastSource(source)) {
-                            source.recycle();
-                        }
-                    } catch (Exception e) {
-                        responseWriter.writeErrorResponse(e);
-                    }
-                    onRequestFulfilled.run();
-                });
-    }
-
-    @Override
-    public boolean isBlockingRequest() {
-        return true;
-    }
-
-    private String getScanContent(AccessibilityNodeInfo rootNode, Bitmap screenshot)
-            throws ScanException, ViewChangedException {
-        if (rootNode == null) {
-            throw new ScanException("Unable to locate root node to scan");
-        }
-        AxeResult axeResult = axeScanner.scanWithAxe(rootNode, screenshot);
-        if (axeResult == null) {
-            throw new ScanException("Scanner returned no data");
-        }
-
-        resultSerializer.addAxeResult(axeResult);
-        return resultSerializer.generateResultJson();
-    }
+    resultSerializer.addAxeResult(axeResult);
+    return resultSerializer.generateResultJson();
+  }
 }

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ResultV1Serializer.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ResultV1Serializer.java
@@ -6,15 +6,15 @@ package com.microsoft.accessibilityinsightsforandroidservice;
 import com.deque.axe.android.AxeResult;
 
 public class ResultV1Serializer {
-    private AxeResult axeResult;
+  private AxeResult axeResult;
 
-    public ResultV1Serializer() {}
+  public ResultV1Serializer() {}
 
-    public void addAxeResult(AxeResult axeResult) {
-        this.axeResult = axeResult;
-    }
+  public void addAxeResult(AxeResult axeResult) {
+    this.axeResult = axeResult;
+  }
 
-    public String generateResultJson() {
-        return this.axeResult.toJson();
-    }
+  public String generateResultJson() {
+    return this.axeResult.toJson();
+  }
 }

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ResultV1Serializer.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ResultV1Serializer.java
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package com.microsoft.accessibilityinsightsforandroidservice;
+
+import com.deque.axe.android.AxeResult;
+
+public class ResultV1Serializer {
+    private AxeResult axeResult;
+
+    public ResultV1Serializer() {}
+
+    public void addAxeResult(AxeResult axeResult) {
+        this.axeResult = axeResult;
+    }
+
+    public String generateResultJson() {
+        return this.axeResult.toJson();
+    }
+}

--- a/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/RequestHandlerFactoryTest.java
+++ b/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/RequestHandlerFactoryTest.java
@@ -28,6 +28,7 @@ public class RequestHandlerFactoryTest {
   @Mock ResponseWriter responseWriter;
   @Mock RequestHandlerImplFactory requestHandlerImplFactory;
   @Mock FocusVisualizationStateManager focusVisualizationStateManager;
+  @Mock ResultV1Serializer resultSerializerV1;
   @Mock ResultsContainerSerializer resultsContainerSerializer;
 
   RequestHandlerFactory testSubject;
@@ -44,18 +45,30 @@ public class RequestHandlerFactoryTest {
             deviceConfigFactory,
             requestHandlerImplFactory,
             focusVisualizationStateManager,
+            resultSerializerV1,
             resultsContainerSerializer);
   }
 
   @Test
-  public void createsResultRequestHandler() {
+  public void createsResultV1RequestHandler() {
     tryCreateRequestHandler("GET /AccessibilityInsights/result something else");
     verify(requestHandlerImplFactory)
         .createRequestHandler(
             any(SocketHolder.class),
-            any(ResultRequestFulfiller.class),
+            any(ResultV1RequestFulfiller.class),
             eq("processResultRequest"),
             eq("*** About to process scan request"));
+  }
+
+  @Test
+  public void createsResultV2RequestHandler() {
+    tryCreateRequestHandler("GET /AccessibilityInsights/result_v2 something else");
+    verify(requestHandlerImplFactory)
+            .createRequestHandler(
+                    any(SocketHolder.class),
+                    any(ResultRequestFulfiller.class),
+                    eq("processResultRequest"),
+                    eq("*** About to process scan request"));
   }
 
   @Test

--- a/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/RequestHandlerFactoryTest.java
+++ b/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/RequestHandlerFactoryTest.java
@@ -64,11 +64,11 @@ public class RequestHandlerFactoryTest {
   public void createsResultV2RequestHandler() {
     tryCreateRequestHandler("GET /AccessibilityInsights/result_v2 something else");
     verify(requestHandlerImplFactory)
-            .createRequestHandler(
-                    any(SocketHolder.class),
-                    any(ResultRequestFulfiller.class),
-                    eq("processResultRequest"),
-                    eq("*** About to process scan request"));
+        .createRequestHandler(
+            any(SocketHolder.class),
+            any(ResultRequestFulfiller.class),
+            eq("processResultRequest"),
+            eq("*** About to process scan request"));
   }
 
   @Test

--- a/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/ResultV1RequestFulfillerTest.java
+++ b/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/ResultV1RequestFulfillerTest.java
@@ -1,0 +1,195 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package com.microsoft.accessibilityinsightsforandroidservice;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import android.graphics.Bitmap;
+import android.view.accessibility.AccessibilityNodeInfo;
+import com.deque.axe.android.AxeResult;
+import java.util.function.Consumer;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.AdditionalAnswers;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ResultV1RequestFulfillerTest {
+
+    @Mock ResponseWriter responseWriter;
+    @Mock RootNodeFinder rootNodeFinder;
+    @Mock EventHelper eventHelper;
+    @Mock AxeScanner axeScanner;
+    @Mock ScreenshotController screenshotController;
+    @Mock Bitmap screenshotMock;
+    @Mock AccessibilityNodeInfo sourceNode;
+    @Mock AccessibilityNodeInfo rootNode;
+    @Mock AxeResult axeResultMock;
+    @Mock RunnableFunction onRequestFulfilledMock;
+    @Mock ResultV1Serializer resultV1Serializer;
+
+    final String scanResultJson = "axe scan result";
+
+    ResultV1RequestFulfiller testSubject;
+
+    @Before
+    public void prepare() {
+        doAnswer(
+                AdditionalAnswers.answerVoid(
+                        (Consumer<Bitmap> bitmapConsumer) -> {
+                            bitmapConsumer.accept(screenshotMock);
+                        }))
+                .when(screenshotController)
+                .getScreenshotWithMediaProjection(any());
+        testSubject =
+                new ResultV1RequestFulfiller(
+                        responseWriter,
+                        rootNodeFinder,
+                        eventHelper,
+                        axeScanner,
+                        screenshotController,
+                        resultV1Serializer);
+    }
+
+    @Test
+    public void resultRequestFulfillerExists() {
+        Assert.assertNotNull(testSubject);
+    }
+
+    @Test
+    public void isBlockingRequestReturnsTrue() {
+        Assert.assertTrue(testSubject.isBlockingRequest());
+    }
+
+    @Test
+    public void callsOnRequestFulfilled() {
+        setupSuccessfulRequest();
+
+        testSubject.fulfillRequest(onRequestFulfilledMock);
+
+        verifyOnRequestFulfilledCalled();
+    }
+
+    @Test
+    public void callsGetScreenshotWithMediaProjection() {
+        setupSuccessfulRequest();
+
+        testSubject.fulfillRequest(onRequestFulfilledMock);
+
+        verify(screenshotController, times(1)).getScreenshotWithMediaProjection(any());
+    }
+
+    @Test
+    public void requestHandledInsideGetScreenshotWithMediaProjection() {
+        reset(screenshotController);
+
+        testSubject.fulfillRequest(onRequestFulfilledMock);
+
+        verifyZeroInteractions(responseWriter);
+        verifyZeroInteractions(onRequestFulfilledMock);
+    }
+
+    @Test
+    public void writesSuccessfulResponse() {
+        setupSuccessfulRequest();
+
+        testSubject.fulfillRequest(onRequestFulfilledMock);
+
+        verify(responseWriter, times(1)).writeSuccessfulResponse(scanResultJson);
+    }
+
+    @Test
+    public void recyclesNodes() {
+        setupSuccessfulRequest();
+
+        testSubject.fulfillRequest(onRequestFulfilledMock);
+
+        verify(rootNode, times(1)).recycle();
+        verify(sourceNode, times(1)).recycle();
+    }
+
+    @Test
+    public void recyclesNodeOnceIfRootEqualsSource() throws ViewChangedException {
+        setupSuccessfulRequest();
+        reset(rootNodeFinder);
+        reset(axeScanner);
+        when(rootNodeFinder.getRootNodeFromSource(any())).thenReturn(sourceNode);
+        when(axeScanner.scanWithAxe(eq(sourceNode), any())).thenReturn(axeResultMock);
+
+        testSubject.fulfillRequest(onRequestFulfilledMock);
+
+        verifyZeroInteractions(rootNode);
+        verify(sourceNode, times(1)).recycle();
+    }
+
+    @Test
+    public void writesErrorIfNoRootNode() {
+        when(rootNodeFinder.getRootNodeFromSource(null)).thenReturn(null);
+
+        testSubject.fulfillRequest(onRequestFulfilledMock);
+
+        verify(responseWriter, times(1))
+                .writeErrorResponse(argThat((e) -> e.getMessage() == "Unable to locate root node to scan"));
+        verifyOnRequestFulfilledCalled();
+    }
+
+    @Test
+    public void writesErrorIfScanFailed() throws ViewChangedException {
+        when(eventHelper.claimLastSource()).thenReturn(sourceNode);
+        when(rootNodeFinder.getRootNodeFromSource(any())).thenReturn(rootNode);
+        when(axeScanner.scanWithAxe(eq(rootNode), any())).thenReturn(null);
+
+        testSubject.fulfillRequest(onRequestFulfilledMock);
+
+        verify(responseWriter, times(1))
+                .writeErrorResponse(argThat((e) -> e.getMessage() == "Scanner returned no data"));
+        verifyOnRequestFulfilledCalled();
+    }
+
+    @Test
+    public void doesNotRecycleSourceIfRestoreLastSourceSucceeds() {
+        setupSuccessfulRequest();
+        when(eventHelper.restoreLastSource(sourceNode)).thenReturn(true);
+
+        testSubject.fulfillRequest(onRequestFulfilledMock);
+        verify(rootNode, times(1)).recycle();
+        verify(sourceNode, never()).recycle();
+    }
+
+    @Test
+    public void addsAxeResultToSerializer() {
+        setupSuccessfulRequest();
+
+        testSubject.fulfillRequest(onRequestFulfilledMock);
+
+        verify(resultV1Serializer, times(1)).addAxeResult(axeResultMock);
+    }
+
+    private void setupSuccessfulRequest() {
+        when(eventHelper.claimLastSource()).thenReturn(sourceNode);
+        when(rootNodeFinder.getRootNodeFromSource(any())).thenReturn(rootNode);
+        try {
+            when(axeScanner.scanWithAxe(eq(rootNode), any())).thenReturn(axeResultMock);
+        } catch (ViewChangedException e) {
+            Assert.fail(e.getMessage());
+        }
+        when(resultV1Serializer.generateResultJson()).thenReturn(scanResultJson);
+    }
+
+    private void verifyOnRequestFulfilledCalled() {
+        verify(onRequestFulfilledMock, times(1)).run();
+    }
+}

--- a/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/ResultV1SerializerTest.java
+++ b/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/ResultV1SerializerTest.java
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package com.microsoft.accessibilityinsightsforandroidservice;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.deque.axe.android.AxeResult;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ResultV1SerializerTest {
+
+    @Mock AxeResult axeResultMock;
+
+    ResultV1Serializer testSubject;
+
+    final String scanResultJson = "axe scan result";
+
+    @Before
+    public void prepare() {
+        testSubject = new ResultV1Serializer();
+    }
+
+    @Test
+    public void resultSerializerExists() {
+        Assert.assertNotNull(testSubject);
+    }
+
+    @Test
+    public void generatesExpectedJson() {
+        when(axeResultMock.toJson()).thenReturn(scanResultJson);
+
+        testSubject.addAxeResult(axeResultMock);
+        String generatedJson = testSubject.generateResultJson();
+
+        verify(axeResultMock, times(1)).toJson();
+        Assert.assertEquals(generatedJson, scanResultJson);
+    }
+}

--- a/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/ResultV1SerializerTest.java
+++ b/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/ResultV1SerializerTest.java
@@ -18,30 +18,30 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class ResultV1SerializerTest {
 
-    @Mock AxeResult axeResultMock;
+  @Mock AxeResult axeResultMock;
 
-    ResultV1Serializer testSubject;
+  ResultV1Serializer testSubject;
 
-    final String scanResultJson = "axe scan result";
+  final String scanResultJson = "axe scan result";
 
-    @Before
-    public void prepare() {
-        testSubject = new ResultV1Serializer();
-    }
+  @Before
+  public void prepare() {
+    testSubject = new ResultV1Serializer();
+  }
 
-    @Test
-    public void resultSerializerExists() {
-        Assert.assertNotNull(testSubject);
-    }
+  @Test
+  public void resultSerializerExists() {
+    Assert.assertNotNull(testSubject);
+  }
 
-    @Test
-    public void generatesExpectedJson() {
-        when(axeResultMock.toJson()).thenReturn(scanResultJson);
+  @Test
+  public void generatesExpectedJson() {
+    when(axeResultMock.toJson()).thenReturn(scanResultJson);
 
-        testSubject.addAxeResult(axeResultMock);
-        String generatedJson = testSubject.generateResultJson();
+    testSubject.addAxeResult(axeResultMock);
+    String generatedJson = testSubject.generateResultJson();
 
-        verify(axeResultMock, times(1)).toJson();
-        Assert.assertEquals(generatedJson, scanResultJson);
-    }
+    verify(axeResultMock, times(1)).toJson();
+    Assert.assertEquals(generatedJson, scanResultJson);
+  }
 }


### PR DESCRIPTION
#### Details

The results API was recently changed in a breaking way (the same API returns differently structured data), which will complicate development and E2E tests for the consuming code. To make our work easier, we've decided that the existing results API will return data in the original structure, and that the differently structured data will be returned through a new results_v2 API. Once we complete the migration of the consuming code, we'll drop the legacy version and support only the request_v2 API. The code in the "V1" classes here was removed in #110.

API change:
Version | Path
--- | ---
V1 (legacy) | `GET localhost://62442/AccessibilityInsights/result`
V2 (new) | `GET localhost://62442/AccessibilityInsights/result_v2`

##### Motivation

This will make it a lot simpler to write E2E tests for the client.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
There will be 2 subsequent PR's here:
- One to specify `V2` in the names of the classes that are specific to the V2 results call (omitted to simplify review)
- One to remove the `V1` classes (after the client has migrated)

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->
In a broader sense, our API's aren't really laid out in a way that nicely supports versioning. The standard that we'd normally follow would be something like `localhost://62442/AccessibilityInsights/api/v2/results`, but doing that "right" would mean updating _all_ of the service calls, and that just doesn't make sense at this time. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] Addresses an existing issue
- [x] Added/updated relevant unit test(s)
- [x] Ran `./gradlew fastpass` from `AccessibilityInsightsForAndroidService`
- [x] PR title _AND_ final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`).
