### PR TITLE
chore: Complete class renames for result_v2 API

### DIFF
--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/RequestHandlerFactory.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/RequestHandlerFactory.java
@@ -16,7 +16,7 @@ public class RequestHandlerFactory {
   private final RequestHandlerImplFactory requestHandlerImplFactory;
   private final FocusVisualizationStateManager focusVisualizationStateManager;
   private final ResultV1Serializer resultV1Serializer;
-  private final ResultsContainerSerializer resultsContainerSerializer;
+  private final ResultsV2ContainerSerializer resultsV2ContainerSerializer;
 
   public RequestHandlerFactory(
       ScreenshotController screenshotController,
@@ -28,7 +28,7 @@ public class RequestHandlerFactory {
       RequestHandlerImplFactory requestHandlerImplFactory,
       FocusVisualizationStateManager focusVisualizationStateManager,
       ResultV1Serializer resultV1Serializer,
-      ResultsContainerSerializer resultsContainerSerializer) {
+      ResultsV2ContainerSerializer resultsV2ContainerSerializer) {
     this.screenshotController = screenshotController;
     this.axeScanner = axeScanner;
     this.atfaScanner = atfaScanner;
@@ -38,7 +38,7 @@ public class RequestHandlerFactory {
     this.requestHandlerImplFactory = requestHandlerImplFactory;
     this.focusVisualizationStateManager = focusVisualizationStateManager;
     this.resultV1Serializer = resultV1Serializer;
-    this.resultsContainerSerializer = resultsContainerSerializer;
+    this.resultsV2ContainerSerializer = resultsV2ContainerSerializer;
   }
 
   public RequestHandler createHandlerForRequest(
@@ -46,23 +46,23 @@ public class RequestHandlerFactory {
     SocketHolder socketHolder = new SocketHolder(socket);
     if (requestString != null) {
       if (requestString.startsWith("GET /AccessibilityInsights/result_v2 ")) {
-        ResultRequestFulfiller resultRequestFulfiller =
-            new ResultRequestFulfiller(
+        ResultV2RequestFulfiller resultV2RequestFulfiller =
+            new ResultV2RequestFulfiller(
                 responseWriter,
                 rootNodeFinder,
                 eventHelper,
                 axeScanner,
                 atfaScanner,
                 screenshotController,
-                resultsContainerSerializer);
+                resultsV2ContainerSerializer);
         return requestHandlerImplFactory.createRequestHandler(
             socketHolder,
-            resultRequestFulfiller,
+            resultV2RequestFulfiller,
             "processResultRequest",
-            "*** About to process scan request");
+            "*** About to process scan request (v2)");
       }
       if (requestString.startsWith("GET /AccessibilityInsights/result ")) {
-        ResultV1RequestFulfiller resultRequestFulfiller =
+        ResultV1RequestFulfiller resultV1RequestFulfiller =
             new ResultV1RequestFulfiller(
                 responseWriter,
                 rootNodeFinder,
@@ -72,9 +72,9 @@ public class RequestHandlerFactory {
                 resultV1Serializer);
         return requestHandlerImplFactory.createRequestHandler(
             socketHolder,
-            resultRequestFulfiller,
+            resultV1RequestFulfiller,
             "processResultRequest",
-            "*** About to process scan request");
+            "*** About to process scan request (v1)");
       }
       if (requestString.startsWith("GET /AccessibilityInsights/config ")) {
         ConfigRequestFulfiller configRequestFulfiller =

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/RequestHandlerFactory.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/RequestHandlerFactory.java
@@ -58,7 +58,7 @@ public class RequestHandlerFactory {
         return requestHandlerImplFactory.createRequestHandler(
             socketHolder,
             resultV2RequestFulfiller,
-            "processResultRequest",
+            "processResultRequestV2",
             "*** About to process scan request (v2)");
       }
       if (requestString.startsWith("GET /AccessibilityInsights/result ")) {
@@ -73,7 +73,7 @@ public class RequestHandlerFactory {
         return requestHandlerImplFactory.createRequestHandler(
             socketHolder,
             resultV1RequestFulfiller,
-            "processResultRequest",
+            "processResultRequestV1",
             "*** About to process scan request (v1)");
       }
       if (requestString.startsWith("GET /AccessibilityInsights/config ")) {

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ResponseThreadFactory.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ResponseThreadFactory.java
@@ -31,7 +31,7 @@ public class ResponseThreadFactory {
             new RequestHandlerImplFactory(),
             focusVisualizationStateManager,
             new ResultV1Serializer(),
-            new ResultsContainerSerializer(
+            new ResultsV2ContainerSerializer(
                 new ATFARulesSerializer(),
                 new ATFAResultsSerializer(new GsonBuilder()),
                 new GsonBuilder()));

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ResultV2RequestFulfiller.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ResultV2RequestFulfiller.java
@@ -10,30 +10,30 @@ import com.google.android.apps.common.testing.accessibility.framework.Accessibil
 import com.google.android.apps.common.testing.accessibility.framework.utils.contrast.BitmapImage;
 import java.util.List;
 
-public class ResultRequestFulfiller implements RequestFulfiller {
+public class ResultV2RequestFulfiller implements RequestFulfiller {
   private final RootNodeFinder rootNodeFinder;
   private final EventHelper eventHelper;
   private final ResponseWriter responseWriter;
   private final AxeScanner axeScanner;
   private final ATFAScanner atfaScanner;
   private final ScreenshotController screenshotController;
-  private final ResultsContainerSerializer resultsContainerSerializer;
+  private final ResultsV2ContainerSerializer resultsV2ContainerSerializer;
 
-  public ResultRequestFulfiller(
+  public ResultV2RequestFulfiller(
       ResponseWriter responseWriter,
       RootNodeFinder rootNodeFinder,
       EventHelper eventHelper,
       AxeScanner axeScanner,
       ATFAScanner atfaScanner,
       ScreenshotController screenshotController,
-      ResultsContainerSerializer resultsContainerSerializer) {
+      ResultsV2ContainerSerializer resultsV2ContainerSerializer) {
     this.responseWriter = responseWriter;
     this.rootNodeFinder = rootNodeFinder;
     this.eventHelper = eventHelper;
     this.axeScanner = axeScanner;
     this.atfaScanner = atfaScanner;
     this.screenshotController = screenshotController;
-    this.resultsContainerSerializer = resultsContainerSerializer;
+    this.resultsV2ContainerSerializer = resultsV2ContainerSerializer;
   }
 
   public void fulfillRequest(RunnableFunction onRequestFulfilled) {
@@ -77,6 +77,6 @@ public class ResultRequestFulfiller implements RequestFulfiller {
     List<AccessibilityHierarchyCheckResult> atfaResults =
         atfaScanner.scanWithATFA(rootNode, new BitmapImage(screenshot));
 
-    return resultsContainerSerializer.createResultsJson(axeResult, atfaResults);
+    return resultsV2ContainerSerializer.createResultsJson(axeResult, atfaResults);
   }
 }

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ResultsV2Container.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ResultsV2Container.java
@@ -7,7 +7,7 @@ import com.deque.axe.android.AxeResult;
 import com.google.android.apps.common.testing.accessibility.framework.AccessibilityHierarchyCheckResult;
 import java.util.List;
 
-public class ResultsContainer {
+public class ResultsV2Container {
   public List<AccessibilityHierarchyCheckResult> ATFAResults;
   public AxeResult AxeResult;
 }

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ResultsV2ContainerSerializer.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ResultsV2ContainerSerializer.java
@@ -13,14 +13,14 @@ import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.util.List;
 
-public class ResultsContainerSerializer {
+public class ResultsV2ContainerSerializer {
   private final ATFARulesSerializer atfaRulesSerializer;
   private final ATFAResultsSerializer atfaResultsSerializer;
   private final Gson gson;
-  private final TypeAdapter<ResultsContainer> resultsContainerTypeAdapter =
-      new TypeAdapter<ResultsContainer>() {
+  private final TypeAdapter<ResultsV2Container> resultsContainerTypeAdapter =
+      new TypeAdapter<ResultsV2Container>() {
         @Override
-        public void write(JsonWriter out, ResultsContainer value) throws IOException {
+        public void write(JsonWriter out, ResultsV2Container value) throws IOException {
           out.beginObject();
           out.name("AxeResults").jsonValue(value.AxeResult.toJson());
           out.name("ATFARules").jsonValue(atfaRulesSerializer.serializeATFARules());
@@ -30,12 +30,12 @@ public class ResultsContainerSerializer {
         }
 
         @Override
-        public ResultsContainer read(JsonReader in) {
+        public ResultsV2Container read(JsonReader in) {
           return null;
         }
       };
 
-  public ResultsContainerSerializer(
+  public ResultsV2ContainerSerializer(
       ATFARulesSerializer atfaRulesSerializer,
       ATFAResultsSerializer atfaResultsSerializer,
       GsonBuilder gsonBuilder) {
@@ -43,13 +43,13 @@ public class ResultsContainerSerializer {
     this.atfaResultsSerializer = atfaResultsSerializer;
     this.gson =
         gsonBuilder
-            .registerTypeAdapter(ResultsContainer.class, this.resultsContainerTypeAdapter)
+            .registerTypeAdapter(ResultsV2Container.class, this.resultsContainerTypeAdapter)
             .create();
   }
 
   public String createResultsJson(
       AxeResult axeResult, List<AccessibilityHierarchyCheckResult> atfaResults) {
-    ResultsContainer container = new ResultsContainer();
+    ResultsV2Container container = new ResultsV2Container();
     container.ATFAResults = atfaResults;
     container.AxeResult = axeResult;
     return gson.toJson(container);

--- a/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/RequestHandlerFactoryTest.java
+++ b/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/RequestHandlerFactoryTest.java
@@ -56,7 +56,7 @@ public class RequestHandlerFactoryTest {
         .createRequestHandler(
             any(SocketHolder.class),
             any(ResultV1RequestFulfiller.class),
-            eq("processResultRequest"),
+            eq("processResultRequestV1"),
             eq("*** About to process scan request (v1)"));
   }
 
@@ -67,7 +67,7 @@ public class RequestHandlerFactoryTest {
         .createRequestHandler(
             any(SocketHolder.class),
             any(ResultV2RequestFulfiller.class),
-            eq("processResultRequest"),
+            eq("processResultRequestV2"),
             eq("*** About to process scan request (v2)"));
   }
 

--- a/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/RequestHandlerFactoryTest.java
+++ b/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/RequestHandlerFactoryTest.java
@@ -29,7 +29,7 @@ public class RequestHandlerFactoryTest {
   @Mock RequestHandlerImplFactory requestHandlerImplFactory;
   @Mock FocusVisualizationStateManager focusVisualizationStateManager;
   @Mock ResultV1Serializer resultSerializerV1;
-  @Mock ResultsContainerSerializer resultsContainerSerializer;
+  @Mock ResultsV2ContainerSerializer resultsV2ContainerSerializer;
 
   RequestHandlerFactory testSubject;
 
@@ -46,7 +46,7 @@ public class RequestHandlerFactoryTest {
             requestHandlerImplFactory,
             focusVisualizationStateManager,
             resultSerializerV1,
-            resultsContainerSerializer);
+            resultsV2ContainerSerializer);
   }
 
   @Test
@@ -57,7 +57,7 @@ public class RequestHandlerFactoryTest {
             any(SocketHolder.class),
             any(ResultV1RequestFulfiller.class),
             eq("processResultRequest"),
-            eq("*** About to process scan request"));
+            eq("*** About to process scan request (v1)"));
   }
 
   @Test
@@ -66,9 +66,9 @@ public class RequestHandlerFactoryTest {
     verify(requestHandlerImplFactory)
         .createRequestHandler(
             any(SocketHolder.class),
-            any(ResultRequestFulfiller.class),
+            any(ResultV2RequestFulfiller.class),
             eq("processResultRequest"),
-            eq("*** About to process scan request"));
+            eq("*** About to process scan request (v2)"));
   }
 
   @Test

--- a/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/ResultV2RequestFulfillerTest.java
+++ b/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/ResultV2RequestFulfillerTest.java
@@ -30,7 +30,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
-public class ResultRequestFulfillerTest {
+public class ResultV2RequestFulfillerTest {
 
   @Mock ResponseWriter responseWriter;
   @Mock RootNodeFinder rootNodeFinder;
@@ -43,12 +43,12 @@ public class ResultRequestFulfillerTest {
   @Mock AccessibilityNodeInfo rootNode;
   @Mock AxeResult axeResultMock;
   @Mock RunnableFunction onRequestFulfilledMock;
-  @Mock ResultsContainerSerializer resultsContainerSerializer;
+  @Mock ResultsV2ContainerSerializer resultsV2ContainerSerializer;
 
   final List<AccessibilityHierarchyCheckResult> atfaResults = Collections.emptyList();
   final String scanResultJson = "axe scan result";
 
-  ResultRequestFulfiller testSubject;
+  ResultV2RequestFulfiller testSubject;
 
   @Before
   public void prepare() {
@@ -60,14 +60,14 @@ public class ResultRequestFulfillerTest {
         .when(screenshotController)
         .getScreenshotWithMediaProjection(any());
     testSubject =
-        new ResultRequestFulfiller(
+        new ResultV2RequestFulfiller(
             responseWriter,
             rootNodeFinder,
             eventHelper,
             axeScanner,
             atfaScanner,
             screenshotController,
-            resultsContainerSerializer);
+            resultsV2ContainerSerializer);
   }
 
   @Test
@@ -184,7 +184,7 @@ public class ResultRequestFulfillerTest {
       Assert.fail(e.getMessage());
     }
     when(atfaScanner.scanWithATFA(eq(sourceNode), any())).thenReturn(atfaResults);
-    when(resultsContainerSerializer.createResultsJson(axeResultMock, atfaResults))
+    when(resultsV2ContainerSerializer.createResultsJson(axeResultMock, atfaResults))
         .thenReturn(scanResultJson);
   }
 

--- a/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/ResultsV2ContainerSerializerTest.java
+++ b/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/ResultsV2ContainerSerializerTest.java
@@ -32,7 +32,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({GsonBuilder.class, Gson.class})
-public class ResultsContainerSerializerTest {
+public class ResultsV2ContainerSerializerTest {
 
   @Mock AxeResult axeResultMock;
   @Mock ATFARulesSerializer atfaRulesSerializer;
@@ -42,40 +42,40 @@ public class ResultsContainerSerializerTest {
   @Mock Gson gson;
 
   final List<AccessibilityHierarchyCheckResult> atfaResults = Collections.emptyList();
-  final ResultsContainer resultsContainer = new ResultsContainer();
+  final ResultsV2Container resultsV2Container = new ResultsV2Container();
 
-  TypeAdapter<ResultsContainer> resultsContainerTypeAdapter;
-  ResultsContainerSerializer testSubject;
+  TypeAdapter<ResultsV2Container> resultsContainerTypeAdapter;
+  ResultsV2ContainerSerializer testSubject;
 
   @Before
   public void prepare() {
     doAnswer(
             AdditionalAnswers.answer(
-                (Type type, TypeAdapter<ResultsContainer> typeAdapter) -> {
+                (Type type, TypeAdapter<ResultsV2Container> typeAdapter) -> {
                   resultsContainerTypeAdapter = typeAdapter;
                   return gsonBuilder;
                 }))
         .when(gsonBuilder)
-        .registerTypeAdapter(eq(ResultsContainer.class), any());
+        .registerTypeAdapter(eq(ResultsV2Container.class), any());
 
     when(gsonBuilder.create()).thenReturn(gson);
-    resultsContainer.AxeResult = axeResultMock;
-    resultsContainer.ATFAResults = atfaResults;
+    resultsV2Container.AxeResult = axeResultMock;
+    resultsV2Container.ATFAResults = atfaResults;
     testSubject =
-        new ResultsContainerSerializer(atfaRulesSerializer, atfaResultsSerializer, gsonBuilder);
+        new ResultsV2ContainerSerializer(atfaRulesSerializer, atfaResultsSerializer, gsonBuilder);
   }
 
   @Test
   public void generatesExpectedJson() {
-    AtomicReference<ResultsContainer> resultsContainer = new AtomicReference<>();
+    AtomicReference<ResultsV2Container> resultsContainer = new AtomicReference<>();
     doAnswer(
             AdditionalAnswers.answer(
-                (ResultsContainer container) -> {
+                (ResultsV2Container container) -> {
                   resultsContainer.set(container);
                   return "Test String";
                 }))
         .when(gson)
-        .toJson(any(ResultsContainer.class));
+        .toJson(any(ResultsV2Container.class));
 
     testSubject.createResultsJson(axeResultMock, atfaResults);
 
@@ -96,7 +96,7 @@ public class ResultsContainerSerializerTest {
     when(jsonWriter.name("ATFARules")).thenReturn(jsonWriter);
     when(jsonWriter.name("ATFAResults")).thenReturn(jsonWriter);
 
-    resultsContainerTypeAdapter.write(jsonWriter, resultsContainer);
+    resultsContainerTypeAdapter.write(jsonWriter, resultsV2Container);
 
     verify(jsonWriter, times(1)).beginObject();
     verify(jsonWriter, times(1)).jsonValue(axeJson);


### PR DESCRIPTION
#### Details

PR #115 included a follow-up to rename classes to reflect their usage in the `result_v2` API. This PR consists of the following:
- Rename `ResultRequestFulfiller` to `ResultV2RequestFulfiller`
- Rename `ResultRequestFulfillerTest` to `ResultV2RequestFulfillerTest`
- Rename `ResultsContainerSerializer` to `ResultsV2ContainerSerializer`
- Rename `ResultsContainerSerializerTest` to `ResultsV2ContainerSerializerTest`
- Update some variable names to better reflect the typing
- Include the result version in logging calls, update corresponding unit tests

##### Motivation

This was a separate PR just to simplify reviewing and tracking the changes

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] Addresses an existing issue:
- [x] Added/updated relevant unit test(s)
- [x] Ran `./gradlew fastpass` from `AccessibilityInsightsForAndroidService`
- [x] PR title _AND_ final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`).
