### PR TITLE
chore: make compiler/lint warnings fail the build

### DIFF
--- a/AccessibilityInsightsForAndroidService/.idea/compiler.xml
+++ b/AccessibilityInsightsForAndroidService/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="1.8" />
+    <bytecodeTargetLevel target="11" />
   </component>
 </project>

--- a/AccessibilityInsightsForAndroidService/.idea/misc.xml
+++ b/AccessibilityInsightsForAndroidService/.idea/misc.xml
@@ -6,7 +6,7 @@
     <option name="priority" value="Medium" />
     <option name="excludeFilter" value="" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/AccessibilityInsightsForAndroidService/.idea/runConfigurations.xml
+++ b/AccessibilityInsightsForAndroidService/.idea/runConfigurations.xml
@@ -3,6 +3,7 @@
   <component name="RunConfigurationProducerService">
     <option name="ignoredProducers">
       <set>
+        <option value="com.android.tools.idea.compose.preview.runconfiguration.ComposePreviewRunConfigurationProducer" />
         <option value="org.jetbrains.plugins.gradle.execution.test.runner.AllInPackageGradleConfigurationProducer" />
         <option value="org.jetbrains.plugins.gradle.execution.test.runner.TestClassGradleConfigurationProducer" />
         <option value="org.jetbrains.plugins.gradle.execution.test.runner.TestMethodGradleConfigurationProducer" />

--- a/AccessibilityInsightsForAndroidService/app/build.gradle
+++ b/AccessibilityInsightsForAndroidService/app/build.gradle
@@ -63,7 +63,8 @@ android {
     testOptions.unitTests.all {
         // This is a workaround for https://github.com/powermock/powermock/issues/969, based on
         // comment https://github.com/powermock/powermock/issues/969#issuecomment-841267805
-        jvmArgs "--add-opens","java.logging/java.util.logging=ALL-UNNAMED",
+        jvmArgs "--illegal-access=warn",
+                "--add-opens","java.logging/java.util.logging=ALL-UNNAMED",
                 "--add-opens","java.base/java.time.zone=ALL-UNNAMED",
                 "--add-opens","java.base/java.lang.reflect=ALL-UNNAMED",
                 "--add-opens","java.base/java.security.cert=ALL-UNNAMED",

--- a/AccessibilityInsightsForAndroidService/app/build.gradle
+++ b/AccessibilityInsightsForAndroidService/app/build.gradle
@@ -33,7 +33,62 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
     lintOptions {
-        abortOnError false
+        checkAllWarnings true
+        warningsAsErrors true
+        abortOnError true
+
+        // GradleDependency and OldTargetApi can start breaking build-over-build due to external
+        // dependency updates, so we treat them as non-fatal to ensure build reproducibility.
+        //
+        // UnknownNullness is grandfathered in as non-fatal only because it already had hundreds
+        // of true positives at the time we enabled warnings-as-errors. It would improve the
+        // codebase to fix all the warnings it generates and make it fatal.
+        warning 'GradleDependency', 'OldTargetApi', 'UnknownNullness'
+
+        // ConvertToWebp is a false positive; it triggers against our launcher icon PNG files, even
+        // though the rule documentation explains that launcher icons must be PNGs and cannot be
+        // converted to Webp.
+        //
+        // GoogleAppIndexWarning is irrelevant to us; we don't ship to the store and don't care if
+        // it can index us, and it's intentional that we don't have a launchable home activity.
+        //
+        // SyntheticAccessor is a legitimate performance warning, but one which is not significant
+        // for a project of our small size (it's only relevant once a project starts bumping up
+        // against the 64K total method limit for jar files).
+        //
+        // UnsafeExperimentalUsageError and UnsafeExperimentalUsageWarning are incomplete,
+        // experimental rules that trigger other false positive warnings if enabled.
+        ignore 'ConvertToWebp', 'GoogleAppIndexingWarning', 'SyntheticAccessor', 'UnsafeExperimentalUsageError', 'UnsafeExperimentalUsageWarning'
+    }
+    testOptions.unitTests.all {
+        // This is a workaround for https://github.com/powermock/powermock/issues/969, based on
+        // comment https://github.com/powermock/powermock/issues/969#issuecomment-841267805
+        jvmArgs "--illegal-access=warn",
+                "--add-opens","java.logging/java.util.logging=ALL-UNNAMED",
+                "--add-opens","java.base/java.time.zone=ALL-UNNAMED",
+                "--add-opens","java.base/java.lang.reflect=ALL-UNNAMED",
+                "--add-opens","java.base/java.security.cert=ALL-UNNAMED",
+                "--add-opens","java.base/java.text=ALL-UNNAMED",
+                "--add-opens","java.base/java.net=ALL-UNNAMED",
+                "--add-opens","java.base/java.nio=ALL-UNNAMED",
+                "--add-opens","java.base/java.nio.charset=ALL-UNNAMED",
+                "--add-opens","java.base/java.nio.file=ALL-UNNAMED",
+                "--add-opens","java.base/sun.nio.fs=ALL-UNNAMED",
+                "--add-opens","java.base/sun.security.x509=ALL-UNNAMED",
+                "--add-opens","java.base/java.util.regex=ALL-UNNAMED",
+                "--add-opens","java.base/java.util.stream=ALL-UNNAMED",
+                "--add-opens","java.base/java.util.concurrent=ALL-UNNAMED",
+                "--add-opens","java.base/java.util.concurrent.atomic=ALL-UNNAMED",
+                "--add-opens","java.base/java.util.concurrent.locks=ALL-UNNAMED",
+                "--add-opens","java.base/java.time=ALL-UNNAMED",
+                "--add-opens","java.base/java.util=ALL-UNNAMED",
+                "--add-opens","java.base/java.io=ALL-UNNAMED",
+                "--add-opens","java.base/java.lang=ALL-UNNAMED"
+    }
+    tasks.withType(JavaCompile) {
+        configure(options) {
+            options.compilerArgs << '-Xlint:deprecation' << '-Xlint:unchecked' << '-Werror'
+        }
     }
 }
 

--- a/AccessibilityInsightsForAndroidService/app/build.gradle
+++ b/AccessibilityInsightsForAndroidService/app/build.gradle
@@ -63,8 +63,7 @@ android {
     testOptions.unitTests.all {
         // This is a workaround for https://github.com/powermock/powermock/issues/969, based on
         // comment https://github.com/powermock/powermock/issues/969#issuecomment-841267805
-        jvmArgs "--illegal-access=warn",
-                "--add-opens","java.logging/java.util.logging=ALL-UNNAMED",
+        jvmArgs "--add-opens","java.logging/java.util.logging=ALL-UNNAMED",
                 "--add-opens","java.base/java.time.zone=ALL-UNNAMED",
                 "--add-opens","java.base/java.lang.reflect=ALL-UNNAMED",
                 "--add-opens","java.base/java.security.cert=ALL-UNNAMED",

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ATFARulesSerializer.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ATFARulesSerializer.java
@@ -77,6 +77,7 @@ public class ATFARulesSerializer {
 
   private class AccessibilityHierarchyCheckAdapterFactory implements TypeAdapterFactory {
     @Override
+    @SuppressWarnings("unchecked")
     public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
       if (!AccessibilityHierarchyCheck.class.isAssignableFrom(type.getRawType())) return null;
 

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/AxeRunnerFactory.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/AxeRunnerFactory.java
@@ -8,8 +8,15 @@ import com.deque.axe.android.AxeConf;
 import com.deque.axe.android.constants.AxeStandard;
 
 public class AxeRunnerFactory {
+  // AxeConf.removeStandard is marked deprecated, but is still suggested in the axe-android docs as
+  // the recommended way to constrain which standards we scan against.
+  //
+  // https://github.com/dequelabs/axe-android/issues/145 tracks the request for a non-deprecated
+  // replacement option.
+  @SuppressWarnings("deprecation")
   public Axe createAxeRunner() {
     AxeConf axeConf = new AxeConf();
+
     axeConf.removeStandard(AxeStandard.BEST_PRACTICE);
     axeConf.removeStandard(AxeStandard.PLATFORM);
     return new Axe(axeConf);

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/OnScreenshotAvailable.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/OnScreenshotAvailable.java
@@ -21,7 +21,7 @@ public class OnScreenshotAvailable implements ImageReader.OnImageAvailableListen
   private BitmapProvider bitmapProvider;
 
   public OnScreenshotAvailable(
-      Consumer<Bitmap> bitmapConsumer, DisplayMetrics metrics, BitmapProvider bitmapProvider) {
+      DisplayMetrics metrics, BitmapProvider bitmapProvider, Consumer<Bitmap> bitmapConsumer) {
     this.bitmapConsumer = bitmapConsumer;
     this.metrics = metrics;
     this.bitmapProvider = bitmapProvider;

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/OnScreenshotAvailableProvider.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/OnScreenshotAvailableProvider.java
@@ -9,7 +9,7 @@ import java.util.function.Consumer;
 
 public class OnScreenshotAvailableProvider {
   public OnScreenshotAvailable getOnScreenshotAvailable(
-      Consumer<Bitmap> bitmapConsumer, DisplayMetrics metrics, BitmapProvider bitmapProvider) {
-    return new OnScreenshotAvailable(bitmapConsumer, metrics, bitmapProvider);
+      DisplayMetrics metrics, BitmapProvider bitmapProvider, Consumer<Bitmap> bitmapConsumer) {
+    return new OnScreenshotAvailable(metrics, bitmapProvider, bitmapConsumer);
   }
 }

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ScreenshotController.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/ScreenshotController.java
@@ -70,7 +70,16 @@ public class ScreenshotController {
   private ImageReader getImageReader(DisplayMetrics metrics, Consumer<Bitmap> bitmapConsumer) {
     ImageReader imageReader =
         ImageReader.newInstance(
-            metrics.widthPixels, metrics.heightPixels, PixelFormat.RGBA_8888, 2);
+            metrics.widthPixels,
+            metrics.heightPixels,
+            // The linter gives a false positive here because it wants us to use one of the
+            // ImageFormat.* constants, but ImageReader.newInstance documents the PixelFormat
+            // constants as being acceptable, too. We don't control the choice of format; it's
+            // determined by the input data we get from the system screenshot functionality.
+            //
+            // noinspection WrongConstant
+            PixelFormat.RGBA_8888,
+            2);
 
     Consumer<Bitmap> onBitmapAvailable =
         bitmap -> {
@@ -80,7 +89,7 @@ public class ScreenshotController {
 
     OnScreenshotAvailable onScreenshotAvailable =
         onScreenshotAvailableProvider.getOnScreenshotAvailable(
-            onBitmapAvailable, metrics, bitmapProvider);
+            metrics, bitmapProvider, onBitmapAvailable);
     imageReader.setOnImageAvailableListener(onScreenshotAvailable, screenshotHandler);
 
     return imageReader;

--- a/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/ATFAResultsSerializerTest.java
+++ b/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/ATFAResultsSerializerTest.java
@@ -73,7 +73,7 @@ public class ATFAResultsSerializerTest {
 
     doAnswer(
             AdditionalAnswers.answer(
-                (Type type, JsonSerializer serializer) -> {
+                (Type type, JsonSerializer<Class> serializer) -> {
                   jsonSerializer = serializer;
                   return gsonBuilder;
                 }))

--- a/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/ConfigRequestFulfillerTest.java
+++ b/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/ConfigRequestFulfillerTest.java
@@ -8,7 +8,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import android.view.accessibility.AccessibilityNodeInfo;
@@ -90,7 +90,7 @@ public class ConfigRequestFulfillerTest {
 
     testSubject.fulfillRequest(onRequestFulfilledMock);
 
-    verifyZeroInteractions(rootNodeMock);
+    verifyNoInteractions(rootNodeMock);
     verify(sourceNodeMock, times(1)).recycle();
   }
 

--- a/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/OnScreenshotAvailableTest.java
+++ b/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/OnScreenshotAvailableTest.java
@@ -58,7 +58,7 @@ public class OnScreenshotAvailableTest {
     imagePlanesStub = new Image.Plane[1];
     imagePlanesStub[0] = imagePlaneMock;
 
-    testSubject = new OnScreenshotAvailable(bitmapConsumerMock, metricsStub, bitmapProviderMock);
+    testSubject = new OnScreenshotAvailable(metricsStub, bitmapProviderMock, bitmapConsumerMock);
   }
 
   @Test

--- a/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/RequestReaderTest.java
+++ b/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/RequestReaderTest.java
@@ -44,7 +44,7 @@ public class RequestReaderTest {
 
   @Test
   public void limitsInputLength() throws IOException {
-    OngoingStubbing bufferedReaderStubbing = when(bufferedReaderMock.read());
+    OngoingStubbing<Integer> bufferedReaderStubbing = when(bufferedReaderMock.read());
     for (int i = 0; i < 300; i++) {
       bufferedReaderStubbing = bufferedReaderStubbing.thenReturn(42);
     }
@@ -58,7 +58,7 @@ public class RequestReaderTest {
   }
 
   private void setupReadLine(String str) {
-    OngoingStubbing bufferedReaderStubbing;
+    OngoingStubbing<Integer> bufferedReaderStubbing;
     try {
       bufferedReaderStubbing = when(bufferedReaderMock.read());
     } catch (IOException e) {

--- a/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/ResultV1RequestFulfillerTest.java
+++ b/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/ResultV1RequestFulfillerTest.java
@@ -11,7 +11,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import android.graphics.Bitmap;
@@ -98,8 +98,8 @@ public class ResultV1RequestFulfillerTest {
 
     testSubject.fulfillRequest(onRequestFulfilledMock);
 
-    verifyZeroInteractions(responseWriter);
-    verifyZeroInteractions(onRequestFulfilledMock);
+    verifyNoInteractions(responseWriter);
+    verifyNoInteractions(onRequestFulfilledMock);
   }
 
   @Test
@@ -131,7 +131,7 @@ public class ResultV1RequestFulfillerTest {
 
     testSubject.fulfillRequest(onRequestFulfilledMock);
 
-    verifyZeroInteractions(rootNode);
+    verifyNoInteractions(rootNode);
     verify(sourceNode, times(1)).recycle();
   }
 

--- a/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/ResultV2RequestFulfillerTest.java
+++ b/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/ResultV2RequestFulfillerTest.java
@@ -11,7 +11,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import android.graphics.Bitmap;
@@ -104,8 +104,8 @@ public class ResultV2RequestFulfillerTest {
 
     testSubject.fulfillRequest(onRequestFulfilledMock);
 
-    verifyZeroInteractions(responseWriter);
-    verifyZeroInteractions(onRequestFulfilledMock);
+    verifyNoInteractions(responseWriter);
+    verifyNoInteractions(onRequestFulfilledMock);
   }
 
   @Test
@@ -137,7 +137,7 @@ public class ResultV2RequestFulfillerTest {
 
     testSubject.fulfillRequest(onRequestFulfilledMock);
 
-    verifyZeroInteractions(rootNode);
+    verifyNoInteractions(rootNode);
     verify(sourceNode, times(1)).recycle();
   }
 

--- a/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/ScreenshotControllerTest.java
+++ b/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/ScreenshotControllerTest.java
@@ -80,7 +80,7 @@ public class ScreenshotControllerTest {
   @Test
   public void createVirtualDisplayWithExpectedImageReader() {
     PowerMockito.mockStatic(ImageReader.class);
-    bitmapConsumerCallback = ArgumentCaptor.forClass(Consumer.class);
+    bitmapConsumerCallback = createBitmapConsumerCallback();
     when(mediaProjectionSupplierMock.get()).thenReturn(mediaProjectionMock);
     when(displayMetricsSupplierMock.get()).thenReturn(displayMetricsStub);
     when(ImageReader.newInstance(
@@ -91,7 +91,7 @@ public class ScreenshotControllerTest {
         .thenReturn(imageReaderMock);
     when(imageReaderMock.getSurface()).thenReturn(surfaceMock);
     when(onScreenshotAvailableProviderMock.getOnScreenshotAvailable(
-            bitmapConsumerCallback.capture(), eq(displayMetricsStub), eq(bitmapProviderMock)))
+            eq(displayMetricsStub), eq(bitmapProviderMock), bitmapConsumerCallback.capture()))
         .thenReturn(onScreenshotAvailableMock);
     when(mediaProjectionMock.createVirtualDisplay(
             "myDisplay",
@@ -109,6 +109,11 @@ public class ScreenshotControllerTest {
 
     verify(displayMock, times(1)).release();
     verify(bitmapConsumerMock, times(1)).accept(bitmapMock);
+  }
+
+  @SuppressWarnings("unchecked")
+  private ArgumentCaptor<Consumer<Bitmap>> createBitmapConsumerCallback() {
+    return ArgumentCaptor.forClass(Consumer.class);
   }
 
   @Test

--- a/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/ServerThreadTest.java
+++ b/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/ServerThreadTest.java
@@ -123,7 +123,7 @@ public class ServerThreadTest {
   public void setupResponseThreadStubs(int numThreads) {
     // Set up a chain of n responseThreadFactory calls
     // (They need to be different objects because we can only run threads once)
-    OngoingStubbing responseThreadFactoryStubbing =
+    OngoingStubbing<ResponseThread> responseThreadFactoryStubbing =
         when(responseThreadFactory.createResponseThread(any()));
     for (int i = 0; i < numThreads - 1; i++) {
       TestableResponseThread responseThreadStub = new TestableResponseThread();

--- a/pipeline/release-build.yaml
+++ b/pipeline/release-build.yaml
@@ -31,7 +31,7 @@ jobs:
           gradleOptions: '-Xmx3072m'
           options: -S -PapkVersionCode=$(APK_VERSION_CODE) -PapkVersionName=$(APK_VERSION_NAME)
           javaHomeOption: 'JDKVersion'
-          jdkVersionOption: '1.8'
+          jdkVersionOption: '1.11'
           jdkArchitectureOption: 'x64'
           publishJUnitResults: true
           testResultsFiles: '**/TEST-*.xml'
@@ -39,6 +39,25 @@ jobs:
 
       - script: type $(system.defaultWorkingDirectory)\AccessibilityInsightsForAndroidService\app\build\outputs\apk\release\output-metadata.json
         displayName: print out generated release APK info
+
+      # lint-results artifact
+
+      - task: CopyFiles@2
+        displayName: (lint-results) copy lint-results files to artifact staging
+        condition: succeededOrFailed()
+        inputs:
+          contents: |
+            lint-results.html
+            lint-results.xml
+          sourceFolder: '$(system.defaultWorkingDirectory)/AccessibilityInsightsForAndroidService/app/build/reports'
+          targetFolder: '$(build.artifactstagingdirectory)/lint-results'
+
+      - task: PublishPipelineArtifact@1
+        displayName: (lint-results) publish lint-results artifact
+        condition: succeededOrFailed()
+        inputs:
+          artifactName: 'lint-results'
+          targetPath: '$(build.artifactstagingdirectory)/lint-results'
 
       # unsigned-apk artifact
 

--- a/pipeline/validation-build.yaml
+++ b/pipeline/validation-build.yaml
@@ -25,5 +25,22 @@ jobs:
           testResultsFiles: '**/TEST-*.xml'
           tasks: 'build'
 
+      - task: CopyFiles@2
+        displayName: (lint-results) copy lint-results files to artifact staging
+        condition: succeededOrFailed()
+        inputs:
+          contents: |
+            lint-results.html
+            lint-results.xml
+          sourceFolder: '$(system.defaultWorkingDirectory))/AccessibilityInsightsForAndroidService/app/build/reports'
+          targetFolder: '$(build.artifactstagingdirectory)/lint-results'
+
+      - task: PublishPipelineArtifact@1
+        displayName: (lint-results) publish lint-results artifact
+        condition: succeededOrFailed()
+        inputs:
+          artifactName: 'lint-results'
+          targetPath: '$(build.artifactstagingdirectory)/lint-results'
+
       - script: node $(system.defaultWorkingDirectory)/pipeline/verify-notice-contents.js
         displayName: verify NOTICE.html content matches lockfile

--- a/pipeline/validation-build.yaml
+++ b/pipeline/validation-build.yaml
@@ -19,7 +19,7 @@ jobs:
           gradleOptions: '-Xmx3072m'
           options: -S
           javaHomeOption: 'JDKVersion'
-          jdkVersionOption: '1.8'
+          jdkVersionOption: '1.11'
           jdkArchitectureOption: 'x64'
           publishJUnitResults: true
           testResultsFiles: '**/TEST-*.xml'

--- a/pipeline/validation-build.yaml
+++ b/pipeline/validation-build.yaml
@@ -32,7 +32,7 @@ jobs:
           contents: |
             lint-results.html
             lint-results.xml
-          sourceFolder: '$(system.defaultWorkingDirectory))/AccessibilityInsightsForAndroidService/app/build/reports'
+          sourceFolder: '$(system.defaultWorkingDirectory)/AccessibilityInsightsForAndroidService/app/build/reports'
           targetFolder: '$(build.artifactstagingdirectory)/lint-results'
 
       - task: PublishPipelineArtifact@1


### PR DESCRIPTION
#### Details

Before this PR, build warnings and lint warnings were being emitted on stdout during builds, but weren't actually blocking the build from succeeding, so they were being ignored and just producing noise.

This PR enables build, test, and compiler warnings to show up as build failures and fixes most pre-existing warnings. This reduces several bits of noise during builds (eg, the "try rebuilding with -Xlint:deprecated" messages and the 6 lines of red WARNING text you get in Android Studio when running tests there).

I've also set up the build to upload a `lint-results` artifact containing lint results (which were previously produced but discarded)

##### Motivation

Avoid noise, fix issues preemptively

##### Context

I included the necessary `.idea` files to run from Android Studio 4.2.2 (latest stable) as part of the PR since I couldn't validate locally otherwise.

The only class of warning which I think would be nice for us to enable but which I didn't include as part of this PR is the `UnknownNullness` lint check, which is similar to strictNullChecks in web; it is a lint which essentially flags any method parameter/etc which has neither a `@NotNull` nor a `@Nullable` annotation. I think being explicit about this is a good idea and approve of the lint rule, but there are ~250 instances of the warning in the codebase so I wanted to leave adding them for a separate PR.

I also intentionally left fixes for the quieted `OldTargetApi` and `GradleDependency` warnings out-of-scope (we'll want to separately investigate why dependabot isn't picking up the old gradle deps)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] Addresses an existing issue: #0000
- [x] Added/updated relevant unit test(s)
- [x] Ran `./gradlew fastpass` from `AccessibilityInsightsForAndroidService`
- [x] PR title _AND_ final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`).
