### PR TITLE
chore: prevent NewerVersionAvailable lint from breaking the build

### DIFF
--- a/AccessibilityInsightsForAndroidService/app/build.gradle
+++ b/AccessibilityInsightsForAndroidService/app/build.gradle
@@ -37,13 +37,14 @@ android {
         warningsAsErrors true
         abortOnError true
 
-        // GradleDependency and OldTargetApi can start breaking build-over-build due to external
-        // dependency updates, so we treat them as non-fatal to ensure build reproducibility.
+        // GradleDependency, NewerVersionAvailable, and OldTargetApi can start breaking
+        // build-over-build due to external dependency updates, so we treat them as non-fatal to
+        // ensure build reproducibility.
         //
         // UnknownNullness is grandfathered in as non-fatal only because it already had hundreds
         // of true positives at the time we enabled warnings-as-errors. It would improve the
         // codebase to fix all the warnings it generates and make it fatal.
-        warning 'GradleDependency', 'OldTargetApi', 'UnknownNullness'
+        warning 'GradleDependency', 'NewerVersionAvailable', 'OldTargetApi', 'UnknownNullness'
 
         // ConvertToWebp is a false positive; it triggers against our launcher icon PNG files, even
         // though the rule documentation explains that launcher icons must be PNGs and cannot be


### PR DESCRIPTION
#### Details

Our lint setup is intended to have "out of date dependency" lints like `GradleDependency` be listed as non-build-breaking warnings, not errors, so they don't block build reproducibility or unrelated PRs. However, we missed one type of lint in that class (`NewerVersionAvailable`) when we set up lint-errors-break-builds a few weeks ago. This PR updates the lint config to treat `NewerVersionAvailable` lint failures as warnings rather than errors.

##### Motivation

Build reproducibility, unblock dependabot PRs #124  and #123 that are currently blocked on each other.

##### Context

n/a


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] Addresses an existing issue: #0000
- [n/a] Added/updated relevant unit test(s)
- [x] Ran `./gradlew fastpass` from `AccessibilityInsightsForAndroidService`
- [x] PR title _AND_ final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`).
