### PR TITLE
fix: Explicitly manage WorkManager.initialize

### DIFF
--- a/AccessibilityInsightsForAndroidService/app/src/main/AndroidManifest.xml
+++ b/AccessibilityInsightsForAndroidService/app/src/main/AndroidManifest.xml
@@ -58,5 +58,10 @@
             android:exported="true"
             android:permission="android.permission.SET_DEBUG_APP">
         </provider>
+        <provider
+            android:name="androidx.work.impl.WorkManagerInitializer"
+            android:authorities="${applicationId}.workmanager-init"
+            android:exported="false"
+            android:enabled="false"/>
     </application>
 </manifest>

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/TempFileProvider.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/TempFileProvider.java
@@ -5,7 +5,6 @@ package com.microsoft.accessibilityinsightsforandroidservice;
 
 import android.content.Context;
 import androidx.annotation.NonNull;
-import androidx.work.Configuration;
 import androidx.work.Data;
 import androidx.work.OneTimeWorkRequest;
 import androidx.work.WorkManager;
@@ -32,7 +31,7 @@ public class TempFileProvider {
   @NonNull private WorkManager workManager;
 
   public TempFileProvider(Context context) {
-    this(context, WorkManagerHolder.GetWorkManager(context));
+    this(context, WorkManagerHolder.getWorkManager(context));
   }
 
   public TempFileProvider(Context context, WorkManager workManager) {

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/TempFileProvider.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/TempFileProvider.java
@@ -5,6 +5,7 @@ package com.microsoft.accessibilityinsightsforandroidservice;
 
 import android.content.Context;
 import androidx.annotation.NonNull;
+import androidx.work.Configuration;
 import androidx.work.Data;
 import androidx.work.OneTimeWorkRequest;
 import androidx.work.WorkManager;
@@ -31,7 +32,7 @@ public class TempFileProvider {
   @NonNull private WorkManager workManager;
 
   public TempFileProvider(Context context) {
-    this(context, WorkManager.getInstance(context));
+    this(context, WorkManagerHolder.GetWorkManager(context));
   }
 
   public TempFileProvider(Context context, WorkManager workManager) {

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/WorkManagerHolder.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/WorkManagerHolder.java
@@ -4,23 +4,22 @@
 package com.microsoft.accessibilityinsightsforandroidservice;
 
 import android.content.Context;
-
 import androidx.work.Configuration;
 import androidx.work.WorkManager;
-
 import java.util.HashMap;
 
 public class WorkManagerHolder {
-    private static HashMap<Context, WorkManager> ContextToManagerMap = new HashMap<Context, WorkManager>();
+  private static HashMap<Context, WorkManager> ContextToManagerMap =
+      new HashMap<Context, WorkManager>();
 
-    public static WorkManager getWorkManager(Context context) {
-        WorkManager managerForContext = ContextToManagerMap.get(context);
+  public static WorkManager getWorkManager(Context context) {
+    WorkManager managerForContext = ContextToManagerMap.get(context);
 
-        if (managerForContext == null) {
-            WorkManager.initialize(context, new Configuration.Builder().build());
-            managerForContext = WorkManager.getInstance(context);
-            ContextToManagerMap.put(context, managerForContext);
-        }
-        return managerForContext;
+    if (managerForContext == null) {
+      WorkManager.initialize(context, new Configuration.Builder().build());
+      managerForContext = WorkManager.getInstance(context);
+      ContextToManagerMap.put(context, managerForContext);
     }
+    return managerForContext;
+  }
 }

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/WorkManagerHolder.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/WorkManagerHolder.java
@@ -13,7 +13,7 @@ import java.util.HashMap;
 public class WorkManagerHolder {
     private static HashMap<Context, WorkManager> ContextToManagerMap = new HashMap<Context, WorkManager>();
 
-    public static WorkManager GetWorkManager(Context context) {
+    public static WorkManager getWorkManager(Context context) {
         WorkManager managerForContext = ContextToManagerMap.get(context);
 
         if (managerForContext == null) {

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/WorkManagerHolder.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/WorkManagerHolder.java
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package com.microsoft.accessibilityinsightsforandroidservice;
+
+import android.content.Context;
+
+import androidx.work.Configuration;
+import androidx.work.WorkManager;
+
+import java.util.HashMap;
+
+public class WorkManagerHolder {
+    private static HashMap<Context, WorkManager> ContextToManagerMap = new HashMap<Context, WorkManager>();
+
+    public static WorkManager GetWorkManager(Context context) {
+        WorkManager managerForContext = ContextToManagerMap.get(context);
+
+        if (managerForContext == null) {
+            WorkManager.initialize(context, new Configuration.Builder().build());
+            managerForContext = WorkManager.getInstance(context);
+            ContextToManagerMap.put(context, managerForContext);
+        }
+        return managerForContext;
+    }
+}


### PR DESCRIPTION
#### Details

As called out in #150, the current code fails to initialize on API 29 or higher. The root problem is that `WorkManager.initialize()` is not being called before the first call to `WorkManager.getInstance()`. If we simply force the call, it gets called by the default handler and fails in a different way. This PR does the following:
- Suppresses automation initialization of `WorkManager` via a manifest change
- Adds a wrapper (`WorkManagerHolder`) that ensures that we only initialize exactly once per `Context`. Since `Context` offers a `getHashCode()` method, we can safely use a `Context` as the key for a `HashMap`. It may be worth pointing out that this isn't thread-safe, but there's no indication that we need to worry about that scenario.
- Gets the `Context`-specific `WorkManager` object by calling `WorkManagerHolder.getWorkManager()` when initializing the production version of `TempFileProvider`

Confirmed that the service initializes correctly on Android API 28 and API 30

##### Motivation

Make the service work

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->
I had hoped to find a way to address this by controlling initialization via the manifest file, but was unable to find the correct combination of changes to make that happen.

I also considered collapsing the `WorkManagerHolder` method to just a method inside the `TempFileProvider` class, but that seemed to oppose the single-responsibility principle

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [x] Addresses an existing issue: #150
- [n/a] Added/updated relevant unit test(s)
- [x] Ran `./gradlew fastpass` from `AccessibilityInsightsForAndroidService`
- [x] PR title _AND_ final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`).
