### PR TITLE
chore: Improve perf and reliability of WorkManagerHolder

### DIFF
--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/WorkManagerHolder.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/WorkManagerHolder.java
@@ -22,7 +22,7 @@ public class WorkManagerHolder {
         managerForContext = WorkManager.getInstance(context);
         ContextToManagerMap.put(context, managerForContext);
       }
+      return managerForContext;
     }
-    return managerForContext;
   }
 }

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/WorkManagerHolder.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/WorkManagerHolder.java
@@ -9,16 +9,19 @@ import androidx.work.WorkManager;
 import java.util.WeakHashMap;
 
 public class WorkManagerHolder {
+  private static final Object LockObject = new Object();
   private static WeakHashMap<Context, WorkManager> ContextToManagerMap =
       new WeakHashMap<Context, WorkManager>();
 
   public static WorkManager getWorkManager(Context context) {
-    WorkManager managerForContext = ContextToManagerMap.get(context);
+    synchronized (LockObject) {
+      WorkManager managerForContext = ContextToManagerMap.get(context);
 
-    if (managerForContext == null) {
-      WorkManager.initialize(context, new Configuration.Builder().build());
-      managerForContext = WorkManager.getInstance(context);
-      ContextToManagerMap.put(context, managerForContext);
+      if (managerForContext == null) {
+        WorkManager.initialize(context, new Configuration.Builder().build());
+        managerForContext = WorkManager.getInstance(context);
+        ContextToManagerMap.put(context, managerForContext);
+      }
     }
     return managerForContext;
   }

--- a/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/WorkManagerHolder.java
+++ b/AccessibilityInsightsForAndroidService/app/src/main/java/com/microsoft/accessibilityinsightsforandroidservice/WorkManagerHolder.java
@@ -6,11 +6,11 @@ package com.microsoft.accessibilityinsightsforandroidservice;
 import android.content.Context;
 import androidx.work.Configuration;
 import androidx.work.WorkManager;
-import java.util.HashMap;
+import java.util.WeakHashMap;
 
 public class WorkManagerHolder {
-  private static HashMap<Context, WorkManager> ContextToManagerMap =
-      new HashMap<Context, WorkManager>();
+  private static WeakHashMap<Context, WorkManager> ContextToManagerMap =
+      new WeakHashMap<Context, WorkManager>();
 
   public static WorkManager getWorkManager(Context context) {
     WorkManager managerForContext = ContextToManagerMap.get(context);


### PR DESCRIPTION
#### Details

#152 used a `HashMap` based on a `Context` object. This can have negative perf implications, so we're changing it to a `WeakHashMap`. We also synchronized calls into the `WorkManagerHolder` to avoid race conditions that would be hard to repro and/or debug.

##### Motivation

Minimize perf impact, improve resiliency.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] Addresses an existing issue:
- [n/a] Added/updated relevant unit test(s)
- [x] Ran `./gradlew fastpass` from `AccessibilityInsightsForAndroidService`
- [x] PR title _AND_ final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`).
