### PR TITLE
chore: Initial pass at adding e2e tests for Android service

### DIFF
--- a/pipeline/e2e-emulator-template.yaml
+++ b/pipeline/e2e-emulator-template.yaml
@@ -1,0 +1,36 @@
+parameters:
+  apiLevel: null
+
+jobs:
+  - job: 'e2e_test_API_${{ parameters.apiLevel }}'
+    dependsOn: 'gradlew_build'
+    pool:
+        vmImage: 'macOS-latest'
+
+    steps:
+      - task: DownloadPipelineArtifact@2
+        inputs:
+          artifact: debugApk
+          path: $(system.defaultWorkingDirectory)
+
+      - task: Bash@3
+        inputs:
+          filePath: 'pipeline/scripts/setup-emulator.sh'
+        env:
+          ANDROID_API_LEVEL: ${{ parameters.apiLevel }}
+
+      - task: Bash@3
+        displayName: Test Config Command
+        inputs:
+          targetType: 'inline'
+          script: |
+            $ANDROID_HOME/platform-tools/adb shell content read --uri content://com.microsoft.accessibilityinsightsforandroidservice/config
+          failOnStderr: true
+
+      - task: Bash@3
+        displayName: Test Result Command
+        inputs:
+          targetType: 'inline'
+          script: |
+            $ANDROID_HOME/platform-tools/adb shell content read --uri content://com.microsoft.accessibilityinsightsforandroidservice/result
+          failOnStderr: true

--- a/pipeline/scripts/setup-emulator.sh
+++ b/pipeline/scripts/setup-emulator.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+emulator_config="system-images;android-$ANDROID_API_LEVEL;google_apis;x86_64"
+emulator_name="emulator_api_$ANDROID_API_LEVEL"
+
+# Install AVD files
+echo "y" | $ANDROID_HOME/tools/bin/sdkmanager --install "$emulator_config"
+# Create emulator
+echo "no" | $ANDROID_HOME/tools/bin/avdmanager create avd -n "$emulator_name" -k "$emulator_config" --force
+
+$ANDROID_HOME/emulator/emulator -list-avds
+
+echo "Starting emulator"
+
+# Start emulator in background
+nohup $ANDROID_HOME/emulator/emulator -avd "$emulator_name" -no-snapshot -no-boot-anim > /dev/null 2>&1 &
+$ANDROID_HOME/platform-tools/adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed | tr -d '\r') ]]; do sleep 1; done; input keyevent 82'
+
+$ANDROID_HOME/platform-tools/adb devices
+echo "Emulator started"
+
+$ANDROID_HOME/platform-tools/adb install app-debug.apk
+$ANDROID_HOME/platform-tools/adb shell appops set com.microsoft.accessibilityinsightsforandroidservice PROJECT_MEDIA allow
+sleep 30
+$ANDROID_HOME/platform-tools/adb shell settings put secure enabled_accessibility_services com.microsoft.accessibilityinsightsforandroidservice/com.microsoft.accessibilityinsightsforandroidservice.AccessibilityInsightsForAndroidService
+sleep 30

--- a/pipeline/validation-build.yaml
+++ b/pipeline/validation-build.yaml
@@ -44,3 +44,25 @@ jobs:
 
       - script: node $(system.defaultWorkingDirectory)/pipeline/verify-clean-lockfile.js
         displayName: verify that building did not change the lockfile unexpectedly
+
+      - task: PublishPipelineArtifact@1
+        displayName: publish artifact
+        inputs:
+          targetPath: '$(system.defaultWorkingDirectory)/AccessibilityInsightsForAndroidService/app/build/outputs/apk/debug/app-debug.apk'
+          artifactName: debugApk
+
+  - template: ./e2e-emulator-template.yaml
+    parameters:
+      apiLevel: 24 # minimum supported
+
+  - template: ./e2e-emulator-template.yaml
+    parameters:
+      apiLevel: 28 
+
+  - template: ./e2e-emulator-template.yaml
+    parameters:
+      apiLevel: 30
+
+  - template: ./e2e-emulator-template.yaml
+    parameters:
+      apiLevel: 32


### PR DESCRIPTION
#### Details
This draft PR contains some initial work to add "e2e tests" for the Android service. The e2e tests consist of some bash scripts that start up an emulator for various API levels and on each one install the service, make a config and result call to the service, and fail if stdErr is not empty. This is a pretty minimal "test", so I'm opening this PR as a draft to gather some feedback on the general approach and next steps. You can find [an example build here](https://dev.azure.com/accessibility-insights/accessibility-insights-for-android-service/_build/results?buildId=34658&view=results).

##### Motivation
We've had a few issues that rendered this service unusable only on particular API levels. This PR will help us avoid similar issues in the future without requiring additional manual testing.

##### Context
Some open questions:
- The bash script in here is based on the [ADO docs for the Android Emulator](https://docs.microsoft.com/en-us/azure/devops/pipelines/ecosystems/android?view=azure-devops#test-on-the-android-emulator). Should we follow this approach or switch it over to be a JS script like the verification scripts already in this repo?
- The "verification" part of this draft just runs some ADB commands directly and verifies stdErr is empty. This should ultimately be improved upon. Is the current state a good enough first step, or do we want to actually validate the responses before merging anything?
- If we want to validate, either as a part of this PR or in the future, should that be done in a script (either bash or JS), or in a [more traditional Android test](https://developer.android.com/training/testing/instrumented-tests)?
- Should these run as a part of PRs, CI, and/or release?
- How many and which APIs should we run these against? I picked 24 (our [minimum supported](https://accessibilityinsights.io/docs/android/reference/faq/#what-are-the-android-apis-supported-by-the-accessibility-insights-for-android-service)), 28 (our targetSdk), 30 (the [most popular](https://apilevels.com/)), and 32 (the latest).

Please feel free to provide any thoughts to these questions or point out new ones!

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] Addresses an existing issue: #0000
- [n/a] Added/updated relevant unit test(s)
- [n/a] Ran `./gradlew fastpass` from `AccessibilityInsightsForAndroidService`
- [x] PR title _AND_ final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`).
