### PR TITLE
chore(deps-dev): migrate release infra scripts to node 16

### DIFF
--- a/pipeline/release-build.yaml
+++ b/pipeline/release-build.yaml
@@ -15,8 +15,8 @@ jobs:
 
       - task: NodeTool@0
         inputs:
-          versionSpec: '12.x'
-        displayName: use node 12.x (latest LTS)
+          versionSpec: '16.x'
+        displayName: use node 16.x (latest LTS)
 
       - script: node $(system.defaultWorkingDirectory)/pipeline/infer-version-code-from-version-name.js
         displayName: validate APK_VERSION_NAME and infer APK_VERSION_CODE


### PR DESCRIPTION
#### Details

Updates our release pipeline to use the latest current LTS version of node (16)

Validated locally by manually running the scripts used by our release pipeline:

* `pipeline/verify-clean-lockfile.js`
* `pipeline/infer-version-code-from-version-name.js`
* `pipeline/verify-notice-contents.js`

##### Motivation

Keep dependencies up to date

##### Context

n/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] Addresses an existing issue: #0000
- [n/a] Added/updated relevant unit test(s)
- [n/a] Ran `./gradlew fastpass` from `AccessibilityInsightsForAndroidService`
- [x] PR title _AND_ final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`).
