### PR TITLE
chore: Enable write permissions for combine-dependabot-prs

### DIFF
--- a/.github/workflows/combine-dependabot-prs.yml
+++ b/.github/workflows/combine-dependabot-prs.yml
@@ -7,6 +7,10 @@ on:
     - cron: '0 13 * * 1'
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   combine-prs:
     if: github.event_name != 'schedule' || github.repository_owner == 'microsoft'


### PR DESCRIPTION
#### Details

Enable write permissions for combine-dependabot-prs

##### Motivation

The repo is configured to only allow read permissions to workflows. The combined-dependabot-prs action requires write permissions to create PRs

##### Context

Tested in [accessibility-insights-web](https://github.com/microsoft/accessibility-insights-web/actions/runs/3499742576)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] Addresses an existing issue: #0000
- [n/a] Added/updated relevant unit test(s)
- [n/a] Ran `./gradlew fastpass` from `AccessibilityInsightsForAndroidService`
- [x] PR title _AND_ final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`).
