### PR TITLE
fix: Upgrading ESRP to fix broken release pipeline

### DIFF
--- a/pipeline/release-build.yaml
+++ b/pipeline/release-build.yaml
@@ -119,7 +119,7 @@ jobs:
         displayName: (signed-apk) rename APK file to remove unsigned qualifier
         workingDirectory: '$(build.artifactstagingdirectory)/signed-apk'
 
-      - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+      - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@2
         displayName: '(signed-apk) sign release APK with ESRP CodeSigning'
         inputs:
           ConnectedServiceName: 'ESRP Code Signing'


### PR DESCRIPTION
#### Details

This PR bumps `EsrpCodeSignign@2` as part of pre-release preparations. 

##### Motivation

Fix broken `Artifact release` pipeline:
https://dev.azure.com/accessibility-insights-private/Accessibility%20Insights%20(private)/_build/results?buildId=40900&view=logs&j=ee97c5d1-e7c0-57b6-e379-76cd471b81bc&t=c8f01bc9-a8db-5eb4-2676-54c8249ded2b

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] Addresses an existing issue: #0000
- [n/a] Added/updated relevant unit test(s)
- [ ] Ran `./gradlew fastpass` from `AccessibilityInsightsForAndroidService`
- [x] PR title _AND_ final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`).
