### PR TITLE
chore: Workaround for mockito #2860

### DIFF
--- a/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/ATFAResultsSerializerTest.java
+++ b/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/ATFAResultsSerializerTest.java
@@ -44,11 +44,10 @@ public class ATFAResultsSerializerTest {
 
   GsonBuilder gsonBuilder = mock(GsonBuilder.class, RETURNS_SELF);
   @Mock Gson gson;
+  @Captor ArgumentCaptor<FieldNamingStrategy> fieldNamingStrategy;
+  @Captor ArgumentCaptor<ExclusionStrategy> exclusiontStrategy;
   JsonSerializer<Class> jsonSerializer;
   ATFAResultsSerializer testSubject;
-
-  @Captor ArgumentCaptor<ExclusionStrategy> exclusiontStrategy;
-  @Captor ArgumentCaptor<FieldNamingStrategy> fieldNamingStrategy;
 
   class TestClass {
     public String testField;

--- a/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/ATFAResultsSerializerTest.java
+++ b/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/ATFAResultsSerializerTest.java
@@ -35,6 +35,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.AdditionalAnswers;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
@@ -46,10 +47,8 @@ public class ATFAResultsSerializerTest {
   JsonSerializer<Class> jsonSerializer;
   ATFAResultsSerializer testSubject;
 
-  ArgumentCaptor<ExclusionStrategy> exclusiontStrategy =
-      ArgumentCaptor.forClass(ExclusionStrategy.class);
-  ArgumentCaptor<FieldNamingStrategy> fieldNamingStrategy =
-      ArgumentCaptor.forClass(FieldNamingStrategy.class);
+  @Captor ArgumentCaptor<ExclusionStrategy> exclusiontStrategy;
+  @Captor ArgumentCaptor<FieldNamingStrategy> fieldNamingStrategy;
 
   class TestClass {
     public String testField;

--- a/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/ATFAResultsSerializerTest.java
+++ b/AccessibilityInsightsForAndroidService/app/src/test/java/com/microsoft/accessibilityinsightsforandroidservice/ATFAResultsSerializerTest.java
@@ -41,7 +41,7 @@ public class ATFAResultsSerializerTest {
   GsonBuilder gsonBuilder = mock(GsonBuilder.class, RETURNS_SELF);
   @Mock Gson gson;
   @Captor ArgumentCaptor<FieldNamingStrategy> fieldNamingStrategy;
-  @Captor ArgumentCaptor<ExclusionStrategy> exclusiontStrategy;
+  @Captor ArgumentCaptor<ExclusionStrategy> exclusionStrategy;
   @Captor ArgumentCaptor<JsonSerializer<Class>> jsonSerializer;
   ATFAResultsSerializer testSubject;
 
@@ -51,12 +51,11 @@ public class ATFAResultsSerializerTest {
 
   @Before
   public void prepare() {
-
     when(gsonBuilder.create()).thenReturn(gson);
 
     testSubject = new ATFAResultsSerializer(gsonBuilder);
 
-    verify(gsonBuilder).setExclusionStrategies(exclusiontStrategy.capture());
+    verify(gsonBuilder).setExclusionStrategies(exclusionStrategy.capture());
     verify(gsonBuilder).setFieldNamingStrategy(fieldNamingStrategy.capture());
     verify(gsonBuilder).registerTypeAdapter(eq(Class.class), jsonSerializer.capture());
   }
@@ -86,9 +85,9 @@ public class ATFAResultsSerializerTest {
             .collect(Collectors.toList());
 
     classesToExclude.forEach(
-        c -> Assert.assertTrue(exclusiontStrategy.getValue().shouldSkipClass(c)));
+        c -> Assert.assertTrue(exclusionStrategy.getValue().shouldSkipClass(c)));
     classesToInclude.forEach(
-        c -> Assert.assertFalse(exclusiontStrategy.getValue().shouldSkipClass(c)));
+        c -> Assert.assertFalse(exclusionStrategy.getValue().shouldSkipClass(c)));
   }
 
   @Test


### PR DESCRIPTION
#### Details

Due to https://github.com/mockito/mockito/issues/2860, Dependbot has been unable to update to any version of `mockito-inline` since version 4.6.1. The failed attempts are as follows:

Version | Failed PR
--- | ---
4.7.0 | #169 
4.8.0 | #174
4.8.1 | #176
4.9.0 | #182
4.11.0 | #198 

In response to https://github.com/mockito/mockito/issues/2860, a suggestion was made to use an `ArgumentCaptor` to capture the arguments and the `RETURNS_SELF` parameter for the builder. This PR makes that change, so we're now capturing arguments using the construct that is intended for that purpose. The mockito team has not committed to fixing this issue and may even be leaning toward not fixing it, since a more officially supported option exists to do what we're doing.

I've applied these changes locally to #198 and confirmed that the tests complete as expected.

##### Motivation

Allow newer versions of mockito

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] Addresses an existing issue:
- [n/a] Added/updated relevant unit test(s)
- [x] Ran `./gradlew fastpass` from `AccessibilityInsightsForAndroidService`
- [x] PR title _AND_ final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`).
