### PR TITLE
chore: fix verify-notice-contents to allow for parens in license expressions

### DIFF
--- a/pipeline/verify-notice-contents.js
+++ b/pipeline/verify-notice-contents.js
@@ -63,7 +63,7 @@ function parseReleaseDepsFromLockfile(path) {
 // output format: ["org.jetbrains/annotations 15.0", ...]
 function parseDepsFromNoticeFile(path) {
     const noticeContent = fs.readFileSync(path).toString();
-    const componentRegex = /\<summary\>\s*([a-zA-Z0-9\._\- \/]+) - ([a-zA-Z0-9\._\-\s]+)\s*\<\/summary\>/gm
+    const componentRegex = /\<summary\>\s*([a-zA-Z0-9\._\- \/@]+) - ([a-zA-Z0-9\._\-\s\(\)]+)\s*\<\/summary\>/gm;
     let captureGroups;
     const deps = [];
     while ((captureGroups = componentRegex.exec(noticeContent)) !== null) {


### PR DESCRIPTION
#### Details

This PR fixes an issue I noticed while porting part of this build script to the web repo.

The specific line in question is a regex that's intended to parse the "Summary" element from a generated NOTICE.html file. These elements look like this:

```html
<summary>
  org.jetbrains/annotations 15.0 - Apache-2.0
</summary>
```

The bug this PR fixes is that the part of the regex that's matching the license (in the above example, `Apache-2.0`) wasn't permissive enough to cover all license expressions used by packages in the web repo. In particular, some packages have complex license expressions that use interesting combinations of licenses, like this:

```html
<summary>
    json-schema 0.4.0 - AFL-2.1 OR BSD-3-Clause OR (AFL-2.1 AND BSD-3-Clause)
</summary>
```

The regex previously got confused in these cases because it didn't allow for `)` or `(` characters as part of the license expression. This PR fixes it to allow parens. With this fix, it's able to parse all the license expressions used by web. This isn't currently required for dependencies of the service, but could feasibly become required in the future, so I backported the fix.

##### Motivation

Prevent future issues if we ever add a dependency with a complex license expression

##### Context

n/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] Addresses an existing issue: #0000
- [n/a] Added/updated relevant unit test(s)
- [x] Ran `./gradlew fastpass` from `AccessibilityInsightsForAndroidService`
- [x] PR title _AND_ final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`).
